### PR TITLE
fix(media): correct audiobookshelf tag (2.35.1 not v2.35.1)

### DIFF
--- a/stacks/selfhosted/media/audiobookshelf.yaml
+++ b/stacks/selfhosted/media/audiobookshelf.yaml
@@ -4,7 +4,7 @@
 services:
   audiobookshelf:
     # renovate: datasource=docker depName=ghcr.io/advplyr/audiobookshelf
-    image: ghcr.io/advplyr/audiobookshelf:v2.35.1
+    image: ghcr.io/advplyr/audiobookshelf:2.35.1
     container_name: audiobookshelf
     restart: unless-stopped
     env_file:


### PR DESCRIPTION
GHCR publishes audiobookshelf without a `v` prefix. `v2.35.1` returns manifest unknown; `2.35.1` is the correct tag. Discovered when the media stack pull failed on the server during deployment.