### PR TITLE
fix: correct immich-kiosk tag and remove wrtag port conflict

### DIFF
--- a/stacks/selfhosted/immich/compose.yaml
+++ b/stacks/selfhosted/immich/compose.yaml
@@ -120,7 +120,7 @@ services:
   # Immich Kiosk - Display mode for photo slideshows
   immich-kiosk:
     # renovate: datasource=docker depName=damongolding/immich-kiosk
-    image: damongolding/immich-kiosk:v0.39.3
+    image: damongolding/immich-kiosk:0.17.2
     container_name: immich_kiosk
     restart: unless-stopped
     env_file:

--- a/stacks/selfhosted/music/wrtag.yaml
+++ b/stacks/selfhosted/music/wrtag.yaml
@@ -30,8 +30,6 @@ services:
       - no-new-privileges:true
     networks:
       - t3_proxy
-    ports:
-      - "127.0.0.1:9091:80"
     volumes:
       # Database and job queue
       - /mnt/fast/appdata/media/wrtag/data:/data


### PR DESCRIPTION
## Summary
- **immich-kiosk**: tag `v0.39.3` does not exist on Docker Hub (latest available is `0.17.2`); our PR #183 pinned the wrong tag — fixed to `0.17.2`
- **wrtag**: port `127.0.0.1:9091` conflicts with `pulse` (system process); removed the `ports:` binding since Traefik handles all routing via the container network

## Test plan
- [ ] Immich stack redeploys cleanly with `0.17.2` kiosk image
- [ ] wrtag starts without port conflict; `wrtag.deercrest.info` accessible via Traefik