### PR TITLE
fix(immich): migrate kiosk image to GHCR (0.39.3)

### DIFF
--- a/stacks/selfhosted/immich/compose.yaml
+++ b/stacks/selfhosted/immich/compose.yaml
@@ -119,8 +119,8 @@ services:
 
   # Immich Kiosk - Display mode for photo slideshows
   immich-kiosk:
-    # renovate: datasource=docker depName=damongolding/immich-kiosk
-    image: damongolding/immich-kiosk:0.17.2
+    # renovate: datasource=docker depName=ghcr.io/damongolding/immich-kiosk
+    image: ghcr.io/damongolding/immich-kiosk:0.39.3
     container_name: immich_kiosk
     restart: unless-stopped
     env_file:


### PR DESCRIPTION
## Summary
- Docker Hub `damongolding/immich-kiosk` was deprecated after v0.17.x — the image now deliberately exits with a migration notice pointing to GHCR
- Updated to `ghcr.io/damongolding/immich-kiosk:0.39.3` (correct registry + correct version)
- Updated Renovate `depName` annotation to track GHCR going forward

## Test plan
- [ ] `immich_kiosk` container starts and stays up
- [ ] `kiosk.deercrest.info` accessible