### PR TITLE
fix(music): roll back wrtag to v0.20.0 (path-format compatibility)

### DIFF
--- a/stacks/selfhosted/music/wrtag.yaml
+++ b/stacks/selfhosted/music/wrtag.yaml
@@ -22,7 +22,8 @@
 
 services:
   wrtag:
-    image: sentriz/wrtag:v0.32.0
+    # v0.30.0 changed path-format fields — pinned to last compatible version; update path-format before upgrading
+    image: sentriz/wrtag:v0.20.0
     container_name: wrtag
     hostname: wrtag
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- wrtag `v0.30.0` changed the path-format data model — the existing `WRTAG_PATH_FORMAT` uses v0.2x field names which are no longer valid
- Rolled back to `v0.20.0` (last version before the breaking change) to restore functionality
- A `WRTAG_PATH_FORMAT` migration is needed before upgrading beyond v0.20.0; see https://github.com/sentriz/wrtag/releases/tag/v0.30.0

## Test plan
- [ ] `wrtag` container starts and stays up
- [ ] `wrtag.deercrest.info` accessible