### PR TITLE
fix(openwebui): mcpo has no semver Docker tags — use main

### DIFF
--- a/stacks/selfhosted/openwebui/compose.yaml
+++ b/stacks/selfhosted/openwebui/compose.yaml
@@ -177,8 +177,8 @@ services:
   # Extensible with custom MCP servers via config.json
   ai-openwebui-mcp:
     container_name: ai-openwebui-mcp
-    # renovate: datasource=docker depName=ghcr.io/open-webui/mcpo
-    image: ghcr.io/open-webui/mcpo:v0.0.20
+    # renovate: datasource=docker depName=ghcr.io/open-webui/mcpo versioning=loose
+    image: ghcr.io/open-webui/mcpo:main
     pull_policy: always
     restart: unless-stopped
     command: --config /app/conf/config.json


### PR DESCRIPTION
mcpo only publishes `main` and `git-*` hash tags to GHCR; `v0.0.20` was a GitHub release tag only. Use `main` to unblock deployment.