### PR TITLE
fix(ci): give compose-validate a project-dir .env for ${VAR} interpolation

### DIFF
--- a/.github/workflows/compose-validate.yaml
+++ b/.github/workflows/compose-validate.yaml
@@ -14,9 +14,15 @@ jobs:
         run: |
           # Create directory structure matching server paths
           sudo mkdir -p /mnt/fast/stacks/stacks/selfhosted/{code-server,immich}
-          # Copy .env.sample to expected .env locations
+          # Copy .env.sample to expected .env locations (satisfies `env_file:` absolute paths)
           sudo cp stacks/selfhosted/code-server/.env.sample /mnt/fast/stacks/stacks/selfhosted/code-server/.env
           sudo cp stacks/selfhosted/immich/.env.sample /mnt/fast/stacks/stacks/selfhosted/immich/.env
+          # Also place .env in each project directory. `env_file:` only injects vars into the
+          # container -- it does NOT feed ${VAR} interpolation in the compose file itself, which
+          # reads the .env next to the compose file. Without this, ${DB_DATA_LOCATION} resolves
+          # to an empty string and `config` fails on ":/var/lib/postgresql/data".
+          cp stacks/selfhosted/code-server/.env.sample stacks/selfhosted/code-server/.env
+          cp stacks/selfhosted/immich/.env.sample stacks/selfhosted/immich/.env
       
       - name: Validate code-server compose
         run: docker compose -f stacks/selfhosted/code-server/compose.yaml config >/dev/null


### PR DESCRIPTION
## Problem

`compose-validate` has been failing on **every** PR with:

```
invalid spec: :/var/lib/postgresql/data: empty section between colons
```

## Root cause

The workflow copied `.env.sample` only to the absolute paths referenced by `env_file:`
(e.g. `/mnt/fast/stacks/stacks/selfhosted/immich/.env`).

But `env_file:` only injects variables **into the container**. It does *not* feed
`${VAR}` interpolation in the compose file itself — that reads the `.env` sitting
next to the compose file.

So `${DB_DATA_LOCATION}` in `stacks/selfhosted/immich/compose.yaml:114` resolved to an
empty string, producing the invalid `:/var/lib/postgresql/data` volume spec.

## Why this mattered

`renovate.json` sets `automerge: true` + `platformAutomerge: true` for patch, minor and
digest updates. The failing required check blocked those automerges, so PRs accumulated
to exactly **10** — `config:recommended`'s default `prConcurrentLimit`. Renovate then
stopped opening new PRs entirely, and the stacks drifted well behind upstream
(ollama 2 minors behind, open-webui 2 minors, docling 4 minors, searxng ~5 weeks).

## Fix

Also copy the samples into the project directories. `.env` is gitignored, so nothing is
committed. `code-server` has no interpolation today, but covering it keeps the two
consistent and avoids the same trap later.

## Verification

Reproduced the exact failure locally, then confirmed the fix clears it:

- Before (no project `.env`): `invalid spec: :/var/lib/postgresql/data: empty section between colons`
- After (project `.env` present): that error is gone; interpolation resolves

The CI log already proves the absolute-path copy works — CI failed on the volume spec,
not on a missing env file — so the project-dir copy was the only missing piece.