### PR TITLE
fix: restart policies for keeper-sh, tsbridge and dawarich

### DIFF
--- a/stacks/selfhosted/dawarich/dawarich.yaml
+++ b/stacks/selfhosted/dawarich/dawarich.yaml
@@ -55,7 +55,7 @@ services:
     tty: true
     entrypoint: web-entrypoint.sh
     command: ['bin/rails', 'server', '-p', '3000', '-b', '::']
-    restart: on-failure
+    restart: unless-stopped
     environment:
       RAILS_ENV: ${RAILS_ENV}
       REDIS_URL: redis://dawarich_redis:6379
@@ -123,7 +123,7 @@ services:
     tty: true
     entrypoint: sidekiq-entrypoint.sh
     command: ['sidekiq']
-    restart: on-failure
+    restart: unless-stopped
     environment:
       RAILS_ENV: ${RAILS_ENV}
       REDIS_URL: redis://dawarich_redis:6379

--- a/stacks/selfhosted/keeper-sh/compose.yaml
+++ b/stacks/selfhosted/keeper-sh/compose.yaml
@@ -25,6 +25,7 @@ services:
   postgres:
     container_name: cal-postgres
     image: postgres:18
+    restart: unless-stopped
     environment:
       POSTGRES_USER: keeper
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
@@ -42,6 +43,7 @@ services:
   redis:
     container_name: cal-redis
     image: redis:7-alpine
+    restart: unless-stopped
     volumes:
       - /mnt/fast/appdata/automation/keeper/redis:/data
     healthcheck:

--- a/stacks/selfhosted/traefik/tsproxy.yaml
+++ b/stacks/selfhosted/traefik/tsproxy.yaml
@@ -26,6 +26,7 @@ services:
     container_name: tsbridge
     # renovate: datasource=docker depName=ghcr.io/jtdowney/tsbridge
     image: ghcr.io/jtdowney/tsbridge:v0.13.1
+    restart: unless-stopped
     command: ["--provider", "docker"]
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock # Required for label discovery


### PR DESCRIPTION
## Problem

A single shutdown at **2026-07-13 14:12:18** took down every container whose compose service
either had no `restart:` policy or one that ignores clean exits. They stayed down for **~2 weeks**.

Nobody noticed, because the *app* containers had `unless-stopped` and dutifully came back — then
crash-looped forever against datastores that would never appear:

```
cal-api     DNSException: getaddrinfo ENOTFOUND
cal-worker  PostgresError: Connection closed
```

Those errors point at the apps, but the apps were fine.

## Root cause

Two distinct mechanisms, same outcome:

| Stack | Service(s) | Was | Why it failed |
|---|---|---|---|
| keeper-sh | `postgres`, `redis` | *(none)* | No policy → never restarts |
| traefik | `tsbridge` | *(none)* | No policy → never restarts |
| dawarich | `dawarich_app`, `dawarich_sidekiq` | `on-failure` | Exited **0** (clean) → `on-failure` declines |

Key trap: **`depends_on: condition: service_healthy` is only evaluated at `compose up` time.**
It does nothing when the Docker daemon or host restarts.

## Impact

- **keeper.sh** fully down ~2 weeks
- **tsbridge** down ~2 weeks, taking **all 9 Tailscale endpoints** with it — `chat`, `search`,
  `ollama`, `docling`, `mcp`, `code`, `photos`, `mc_vanilla`, `mc_yggdrasil`
- **dawarich** web app down ~2 weeks (sidekiq worker stayed up, so it looked half-alive)

## Fix

`restart: unless-stopped` on all five services.

A repo-wide scan (parse every compose yaml; flag services with `image`/`build` but no
`restart`/`deploy`) confirms these were the only gaps.

## Verification

keeper.sh and tsbridge are already restored on the host (`docker update --restart` applied to the
live containers); this PR makes it survive recreation.

- keeper.sh: all 6 containers `Up`, postgres/redis `(healthy)`,
  `https://keeper.deercrest.info/` → 307 → **200** at `/login`, DB intact (24 tables)
- tsbridge: `Up`, re-primed TLS for all 9 Tailscale endpoints
- dawarich: not yet restarted — doing so also upgrades 1.9.1 → 1.10.3 (per #198), which runs
  migrations, so it is being handled as a deliberate step rather than folded in here