### PR TITLE
chore(karakeep): disable karakeep-mcp — it is a stdio server, not HTTP

### DIFF
--- a/stacks/selfhosted/karakeep/compose.yaml
+++ b/stacks/selfhosted/karakeep/compose.yaml
@@ -74,32 +74,49 @@ services:
     networks:
       - default
 
-  mcp:
-    container_name: karakeep-mcp
-    hostname: karakeep-mcp
-    # renovate: datasource=docker depName=ghcr.io/karakeep-app/karakeep-mcp
-    image: ghcr.io/karakeep-app/karakeep-mcp:0.31.0
-    restart: unless-stopped
-    volumes:
-      - /mnt/fast/appdata/hoarder/karakeep/data:/data
-    env_file:
-      - .env
-    environment:
-      DATA_DIR: /data
-    depends_on:
-      - web
-    networks:
-      - default
-      - t3_proxy
-    ports:
-      - 127.0.0.1:3004:3001
-    labels:
-      - traefik.enable=true
-      - traefik.http.routers.karakeep-mcp.rule=Host(`karakeep-mcp.${DOMAINNAME}`)
-      - traefik.http.routers.karakeep-mcp.entrypoints=web,websecure
-      - traefik.http.routers.karakeep-mcp.tls=true
-      - traefik.http.routers.karakeep-mcp.tls.certresolver=dns-cloudflare
-      - traefik.http.services.karakeep-mcp.loadbalancer.server.port=3001
+  # DISABLED 2026-07-30 -- karakeep-mcp is a STDIO MCP server, not an HTTP one.
+  #
+  # It is designed to be launched on demand by an MCP client (Claude Desktop etc.)
+  # via `docker run` with stdin attached, per
+  # https://docs.karakeep.app/integrations/mcp/ -- the only documented settings are
+  # KARAKEEP_API_ADDR and KARAKEEP_API_KEY. There is no HTTP transport or port option.
+  #
+  # Run as a long-lived service with no stdin it gets EOF immediately and exits 0,
+  # producing a silent restart loop (71 restarts observed, zero log output). The
+  # `ports:` and traefik labels below implied an HTTP server that this image does not
+  # provide, and KARAKEEP_API_ADDR / KARAKEEP_API_KEY were never set either.
+  #
+  # Streamable HTTP support exists only in an UNMERGED upstream PR:
+  #   https://github.com/karakeep-app/karakeep/pull/1971
+  # Re-enable this (with the transport flag and API vars) once that ships in a release.
+  #
+  # mcp:
+  #   container_name: karakeep-mcp
+  #   hostname: karakeep-mcp
+  #   # renovate: datasource=docker depName=ghcr.io/karakeep-app/karakeep-mcp
+  #   image: ghcr.io/karakeep-app/karakeep-mcp:0.31.0
+  #   restart: unless-stopped
+  #   volumes:
+  #     - /mnt/fast/appdata/hoarder/karakeep/data:/data
+  #   env_file:
+  #     - .env
+  #   environment:
+  #     DATA_DIR: /data
+  #   depends_on:
+  #     - web
+  #   networks:
+  #     - default
+  #     - t3_proxy
+  #   ports:
+  #     - 127.0.0.1:3004:3001
+  #   labels:
+  #     - traefik.enable=true
+  #     - traefik.http.routers.karakeep-mcp.rule=Host(`karakeep-mcp.${DOMAINNAME}`)
+  #     - traefik.http.routers.karakeep-mcp.entrypoints=web,websecure
+  #     - traefik.http.routers.karakeep-mcp.tls=true
+  #     - traefik.http.routers.karakeep-mcp.tls.certresolver=dns-cloudflare
+  #     - traefik.http.services.karakeep-mcp.loadbalancer.server.port=3001
+
   chrome:
     container_name: karakeep-chrome
     # renovate: datasource=docker depName=gcr.io/zenika-hub/alpine-chrome


### PR DESCRIPTION
## Problem

`karakeep-mcp` has been in a silent restart loop — **71 restarts, zero bytes of log output**,
exit code 0 every time.

## Root cause

The service was configured as a long-lived daemon with `ports: 127.0.0.1:3004:3001` and Traefik
labels, implying a network-hosted MCP endpoint that Claude could connect to over HTTP.

**It isn't one.** Per the [official docs](https://docs.karakeep.app/integrations/mcp/),
`ghcr.io/karakeep-app/karakeep-mcp` is a **stdio** MCP server, launched on demand by an MCP client
via `docker run` with stdin attached. The only documented configuration is `KARAKEEP_API_ADDR` and
`KARAKEEP_API_KEY` — there is no HTTP transport or port setting.

Confirmed on the host: `Entrypoint=[node index.js]`, `OpenStdin=false`, `Tty=false`, and neither
API variable set. With no stdin it gets EOF immediately and exits cleanly, so `unless-stopped`
restarts it forever.

## Why not just upgrade

Streamable HTTP support exists only in **unmerged** upstream PR
[karakeep-app/karakeep#1971](https://github.com/karakeep-app/karakeep/pull/1971). It is not in any
release, including v0.32.0. There is no version to upgrade to that provides this.

## Fix

Commented out rather than deleted, with the reasoning inline, so it can be restored (with the
transport flag and API vars) once upstream ships it.

The container is already stopped on the host with `restart=no`.

## Verification

`docker compose config --services` still resolves cleanly: `chrome`, `meilisearch`, `web`, `workers`.