### PR TITLE
fix(renovate): unblock stuck updates, prevent re-jamming, hold wrtag

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,8 @@
     "config:recommended"
   ],
   "pinDigests": false,
+  "// internalChecksFilter": "Do NOT hold updates whose release age cannot be determined. minimumReleaseAge needs a release timestamp, which GHCR/quay/lscr/ECR do not reliably expose. With the default 'strict', every non-Docker-Hub image sat in the Dependency Dashboard's 'Pending Status Checks' forever -- 30 updates stuck, including immich, karakeep, open-webui and keeper, while Docker Hub images updated normally.",
+  "internalChecksFilter": "none",
   "enabledManagers": [
     "docker-compose",
     "dockerfile"
@@ -12,7 +14,7 @@
     "managerFilePatterns": [
       "(^|/)(compose\\.ya?ml|docker-compose\\.ya?ml)$",
       "/(^|/)(compose\\.ya?ml|docker-compose\\.ya?ml)$/",
-      "/stacks/selfhosted/.*\.ya?ml$/"
+      "/stacks/selfhosted/.*\\.ya?ml$/"
     ]
   },
   "labels": [
@@ -459,6 +461,8 @@
       ]
     }
   ],
+  "// prConcurrentLimit": "Raised from the config:recommended default of 10. Major updates are automerge:false by design and sit open awaiting review; at a limit of 10 those permanently occupy slots and eventually block ALL other updates -- which is how the pipeline jammed in 2026-07.",
+  "prConcurrentLimit": 20,
   "prHourlyLimit": 6,
   "minimumReleaseAge": "3 hours",
   "schedule": [

--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,8 @@
     "config:recommended"
   ],
   "pinDigests": false,
-  "// internalChecksFilter": "Do NOT hold updates whose release age cannot be determined. minimumReleaseAge needs a release timestamp, which GHCR/quay/lscr/ECR do not reliably expose. With the default 'strict', every non-Docker-Hub image sat in the Dependency Dashboard's 'Pending Status Checks' forever -- 30 updates stuck, including immich, karakeep, open-webui and keeper, while Docker Hub images updated normally.",
+  "// minimumReleaseAge": "REMOVED deliberately -- do not reinstate without reading this. It requires a release timestamp, which GHCR/quay/lscr/ECR do not reliably expose. When the age cannot be determined Renovate leaves the 'renovate/stability-days' status check PENDING FOREVER, not just for the configured window. Observed 2026-07-30: booklore v2.3.1 and d365fo-client v0.3.8 (both months old) reported 'Updates have not met minimum release age requirement'. That pending check makes every PR UNSTABLE, which blocks automerge, and under the default internalChecksFilter it also stopped the PRs being created at all -- 30 updates frozen on the Dependency Dashboard, 25 of them GHCR, while Docker Hub images flowed normally.",
+  "// internalChecksFilter": "Belt-and-braces alongside removing minimumReleaseAge: never withhold PR creation because an internal check cannot be satisfied.",
   "internalChecksFilter": "none",
   "enabledManagers": [
     "docker-compose",
@@ -56,8 +57,7 @@
       "platformAutomerge": true,
       "schedule": [
         "at any time"
-      ],
-      "minimumReleaseAge": "1 hour"
+      ]
     },
     {
       "description": "Default: Auto-merge minor updates for all Docker images",
@@ -75,8 +75,22 @@
       "platformAutomerge": true,
       "schedule": [
         "at any time"
+      ]
+    },
+    {
+      "description": "wrtag: HOLD at v0.20.x -- v0.30.0 changed path-format fields. WRTAG_PATH_FORMAT in stacks/selfhosted/music/wrtag.yaml uses .Release.Date.Year, .Release.Media, .Track.Position and artistsString, which that release reworked. PR #191 was already a rollback for exactly this. Rewrite the path-format first, then raise allowedVersions. Without this rule the automerge rules above would silently land v0.33.0 and break music tagging again.",
+      "matchDatasources": [
+        "docker"
       ],
-      "minimumReleaseAge": "3 hours"
+      "matchPackageNames": [
+        "sentriz/wrtag"
+      ],
+      "allowedVersions": "<0.30.0",
+      "addLabels": [
+        "stack:music",
+        "pinned",
+        "manual-update-only"
+      ]
     },
     {
       "description": "Security: Pin digests for security-critical components",
@@ -464,7 +478,6 @@
   "// prConcurrentLimit": "Raised from the config:recommended default of 10. Major updates are automerge:false by design and sit open awaiting review; at a limit of 10 those permanently occupy slots and eventually block ALL other updates -- which is how the pipeline jammed in 2026-07.",
   "prConcurrentLimit": 20,
   "prHourlyLimit": 6,
-  "minimumReleaseAge": "3 hours",
   "schedule": [
     "at any time"
   ]


### PR DESCRIPTION
## Problem

The Dependency Dashboard ([#3](../issues/3)) held **30 updates** under *"Pending Status Checks"* —
branches created, PRs never opened. Some stuck for months (karakeep v0.32.0 released 2026-05-08).

## Root cause 1 — `minimumReleaseAge` is unsatisfiable on these registries

The split across the 30 pending items was perfect:

| Registry | Pending |
|---|---|
| `ghcr.io` | 25 |
| `quay.io` | 1 |
| `public.ecr.aws` | 1 |
| `lscr.io` | 1 |
| **Docker Hub** | **0** |

Every update Renovate *did* create was Docker Hub (traefik, prometheus, grafana, nginx, ollama,
meilisearch, pgvector, wrtag, romm…).

**Confirmed directly** by forcing PR creation from the dashboard — the resulting PRs came back
`UNSTABLE`, blocked by:

```
renovate/stability-days   pending
Updates have not met minimum release age requirement
```

booklore v2.3.1 and d365fo-client v0.3.8 are **months** old. `minimumReleaseAge` needs a release
timestamp, which GHCR doesn't reliably expose, so the check stays pending **forever** — not for the
3-hour window.

Two settings are therefore needed, and one alone is not enough:
- `internalChecksFilter: "none"` → lets the PR be **created**
- removing `minimumReleaseAge` (global + both packageRules) → lets it **merge**

Unblocks: **immich**, karakeep ×3, open-webui, keeper ×4, tsbridge, audiobookshelf, seerr,
code-server, teleport, docling, homarr, postiz, freshrss, autobrr, dispatcharr, flaresolverr,
wizarr and more.

## Root cause 2 — the concurrent limit would re-jam

`prConcurrentLimit` was unset → default **10**. The pending list holds **4 majors** (immich v3,
sabnzbd v5, paperless-ngx v3, boxarr v2) plus open romm v5. Majors are `automerge: false` by design
and sit open awaiting review, permanently occupying slots — which is exactly how the pipeline
jammed before (#204). Raised to **20**.

## Root cause 3 — invalid JSON

```diff
- "/stacks/selfhosted/.*\.ya?ml$/"
+ "/stacks/selfhosted/.*\\.ya?ml$/"
```

`\.` is not a valid JSON escape. Renovate warned it would stop accepting this. The file now parses
as strict JSON.

## Also: hold `sentriz/wrtag` below v0.30.0

Not cosmetic — this prevents an imminent silent breakage. PR #209 (wrtag v0.33.0) is labelled
`automerge`+`safe` with `mergeStateStatus: CLEAN`, and the "auto-merge all minor docker updates"
rule covers it. Once Renovate re-enables platform automerge it lands by itself.

But `wrtag.yaml` says:

```yaml
# v0.30.0 changed path-format fields — pinned to last compatible version; update path-format before upgrading
image: sentriz/wrtag:v0.20.0
```

`WRTAG_PATH_FORMAT` uses `.Release.Date.Year`, `.Release.Media`, `.Track.Position`,
`artistsString` — all reworked in v0.30.0. PR #191 was already a rollback for this exact reason.
This turns that comment into an enforced `allowedVersions: "<0.30.0"` rule.

Reversible: rewrite the path-format, then raise `allowedVersions`.

## Verification

`renovate.json` parses as strict JSON (previously `Invalid \escape: line 15 column 29`).
No `minimumReleaseAge` remains at any level.