### PR TITLE
docs(sabnzbd): record that init scripts are now vendored, not auto-downloaded

### DIFF
--- a/stacks/selfhosted/arrs/sabnzbd.yaml
+++ b/stacks/selfhosted/arrs/sabnzbd.yaml
@@ -40,7 +40,19 @@ services:
       - "8084:8080"
     volumes:
       - /mnt/fast/appdata/arrs/sabnzbd/config:/config:rw  # Application config, queue, and history database
-      - /mnt/fast/appdata/arrs/sabnzbd/arr-scripts:/custom-cont-init.d  # Post-processing scripts
+      # Init scripts. NOTE (2026-07-31): arr-scripts/scripts_init.bash is a VENDORED copy of
+      # RandomNinjaAtk/arr-scripts sabnzbd/setup.bash v3.2, with the blocks that download and
+      # overwrite /config/scripts/{video,audio,audiobook}.bash removed. It no longer does
+      # `curl <upstream> | bash` on every container start.
+      #
+      # Why: SABnzbd 5.0 runs post-processing scripts for FAILED jobs too (empty_postproc was
+      # removed upstream), and arr-scripts has no job-status check. Those three scripts now carry
+      # a local SAB_PP_STATUS guard, and are only durable because setup no longer re-downloads
+      # them. Restoring the stock setup.bash silently reverts the guard and lets failed
+      # downloads be post-processed into the library.
+      #
+      # The scripts live in /config/scripts (persistent) -- see each file's header for provenance.
+      - /mnt/fast/appdata/arrs/sabnzbd/arr-scripts:/custom-cont-init.d  # Post-processing scripts (vendored, see above)
       - /mnt/tank/downloads:/downloads:rw  # Download output directory (incomplete and complete)
     environment:
       PUID: $PUID


### PR DESCRIPTION
## Context

Preparation for the sabnzbd v5 upgrade (held on the Dependency Dashboard).

## What changed on the host

`arr-scripts/scripts_init.bash` previously ran, on **every container start**:

```bash
curl .../RandomNinjaAtk/arr-scripts/main/sabnzbd/setup.bash | bash
```

That `setup.bash` unconditionally `rm`s and re-downloads
`/config/scripts/{video,audio,audiobook}.bash` (lines 83–122 upstream), so **any local change to
them was silently reverted** whenever the container was recreated — which is exactly what a version
upgrade does.

It is now a **vendored copy of upstream v3.2** with only those download blocks removed. Package
installation (apk, pip/beets, SMA clone) is retained — that genuinely must run per-container.

## Why it was necessary

SABnzbd 5.0's headline breaking change:

> Post-processing scripts will always be executed, **even for failed jobs** — you must check the
> job status inside your scripts. `empty_postproc` was removed.

Verified 2026-07-31: upstream `video.bash` v3.6, `audio.bash` v1.9 and `audiobook.bash` v1.7 contain
**zero** `SAB_PP_STATUS` references. Your installed copies were byte-identical to upstream. Without
a guard, failed/incomplete downloads would be post-processed into the library.

Each script now carries a local guard:

```bash
sab_status="${SAB_PP_STATUS:-${7:-0}}"
if [ "$sab_status" != "0" ]; then
  echo "... post-processing skipped :: job status $sab_status (not 0/success)"
  exit 0
fi
```

## Verification

Force-recreated the container (equivalent to an upgrade):

| Check | Result |
|---|---|
| Guard survived recreation | ✅ all 3 scripts, 4 `SAB_PP_STATUS` refs each |
| Vendored header intact | ✅ all 3 |
| Vendored setup ran | ✅ `Setup Script Version: 3.2`, packages installed |
| Script re-downloads | ✅ none |
| sabnzbd local | ✅ HTTP 200 |
| sabnzbd via traefik | ✅ HTTP 200 |

Behaviour tested directly: `SAB_PP_STATUS=3` → skips and exits 0; `SAB_PP_STATUS=0` → proceeds.

Backups at `/mnt/fast/appdata/arrs/sabnzbd/backup-20260731/` (original scripts, `scripts_init.bash`,
`sabnzbd.ini`).

## This PR

Comment only — documents the above at the mount point so it isn't lost. No functional change.