### PR TITLE
fix(paperless-gpt): use LLM_PROVIDER/LLM_MODEL schema required by v0.2x

### DIFF
--- a/stacks/selfhosted/documents/.env.sample
+++ b/stacks/selfhosted/documents/.env.sample
@@ -41,7 +41,9 @@ LLM_LANGUAGE=English
 # (also uncomment OLLAMA_HOST in paperless-gpt.yaml)
 
 # AI Features
-PAPERLESS_GPT_AUTO_TAG=true
+# PAPERLESS_GPT_AUTO_TAG is the NAME of the paperless tag that triggers auto-processing,
+# NOT a boolean. Tag a document with this in paperless to have paperless-gpt process it.
+PAPERLESS_GPT_AUTO_TAG=paperless-gpt-auto
+PAPERLESS_GPT_AUTO_GENERATE_TAGS=true
 PAPERLESS_GPT_AUTO_CORRESPONDENT=true
 PAPERLESS_GPT_AUTO_DOCUMENT_TYPE=true
-PAPERLESS_GPT_INTERVAL=300

--- a/stacks/selfhosted/documents/.env.sample
+++ b/stacks/selfhosted/documents/.env.sample
@@ -27,15 +27,18 @@ TZ=America/New_York
 # Paperless API
 PAPERLESS_GPT_API_TOKEN=YOUR_PAPERLESS_API_TOKEN_FROM_SETTINGS
 
-# OpenAI Configuration
+# LLM Configuration
+# paperless-gpt >= v0.2x uses LLM_PROVIDER + LLM_MODEL (see paperless-gpt.yaml).
+# OPENAI_MODEL below is mapped to LLM_MODEL; OPENAI_BASE_URL is no longer read.
+LLM_PROVIDER=openai
 OPENAI_API_KEY=YOUR_OPENAI_API_KEY
 OPENAI_MODEL=gpt-4o-mini
-OPENAI_BASE_URL=https://api.openai.com/v1
+LLM_LANGUAGE=English
 
-# Optional: Use local LLM (OpenClaw on Cerebro VM)
-# OPENAI_BASE_URL=http://172.16.1.160:11434/v1
-# OPENAI_MODEL=llama3
-# OPENAI_API_KEY=not-needed-for-local
+# Optional: Use a local LLM via the ai-ollama container instead
+# LLM_PROVIDER=ollama
+# OPENAI_MODEL=qwen2.5:3b
+# (also uncomment OLLAMA_HOST in paperless-gpt.yaml)
 
 # AI Features
 PAPERLESS_GPT_AUTO_TAG=true

--- a/stacks/selfhosted/documents/paperless-gpt.yaml
+++ b/stacks/selfhosted/documents/paperless-gpt.yaml
@@ -14,15 +14,21 @@ services:
       - PAPERLESS_BASE_URL=http://paperless:8000
       - PAPERLESS_API_TOKEN=${PAPERLESS_GPT_API_TOKEN}
       
-      # OpenAI/LLM configuration
+      # LLM configuration.
+      # NOTE: paperless-gpt >= v0.2x uses LLM_PROVIDER + LLM_MODEL. The older
+      # OPENAI_MODEL / OPENAI_BASE_URL pair is NOT read any more -- without
+      # LLM_PROVIDER the container exits with:
+      #   fatal msg="Please set the LLM_PROVIDER environment variable."
+      - LLM_PROVIDER=${LLM_PROVIDER:-openai}
+      - LLM_MODEL=${OPENAI_MODEL:-gpt-4o-mini}
       - OPENAI_API_KEY=${OPENAI_API_KEY}
-      - OPENAI_MODEL=${OPENAI_MODEL:-gpt-4o-mini}
-      - OPENAI_BASE_URL=${OPENAI_BASE_URL:-https://api.openai.com/v1}
-      
-      # Optional: Use local LLM (Ollama/OpenClaw)
-      # - OPENAI_BASE_URL=http://172.16.1.160:11434/v1
-      # - OPENAI_MODEL=llama3
-      
+      - LLM_LANGUAGE=${LLM_LANGUAGE:-English}
+
+      # Optional: use a local LLM instead (e.g. the ai-ollama container)
+      # - LLM_PROVIDER=ollama
+      # - LLM_MODEL=qwen2.5:3b
+      # - OLLAMA_HOST=http://ai-ollama:11434
+
       # Features
       - AUTO_TAG=${PAPERLESS_GPT_AUTO_TAG:-true}
       - AUTO_CORRESPONDENT=${PAPERLESS_GPT_AUTO_CORRESPONDENT:-true}

--- a/stacks/selfhosted/documents/paperless-gpt.yaml
+++ b/stacks/selfhosted/documents/paperless-gpt.yaml
@@ -29,13 +29,18 @@ services:
       # - LLM_MODEL=qwen2.5:3b
       # - OLLAMA_HOST=http://ai-ollama:11434
 
-      # Features
-      - AUTO_TAG=${PAPERLESS_GPT_AUTO_TAG:-true}
-      - AUTO_CORRESPONDENT=${PAPERLESS_GPT_AUTO_CORRESPONDENT:-true}
-      - AUTO_DOCUMENT_TYPE=${PAPERLESS_GPT_AUTO_DOCUMENT_TYPE:-true}
-      
-      # Processing
-      - PROCESSING_INTERVAL=${PAPERLESS_GPT_INTERVAL:-300}
+      # Features.
+      # IMPORTANT: AUTO_TAG is the NAME of the paperless tag that triggers auto-processing
+      # (upstream default: paperless-gpt-auto). It is NOT a boolean -- the old value of
+      # "true" made paperless-gpt watch for a tag literally named "true", which it logged as
+      #   Using true as auto tag
+      # AUTO_CORRESPONDENT / AUTO_DOCUMENT_TYPE / PROCESSING_INTERVAL do not exist upstream
+      # and were silently ignored; the real names are AUTO_GENERATE_*. There is no
+      # processing-interval setting upstream at all.
+      - AUTO_TAG=${PAPERLESS_GPT_AUTO_TAG:-paperless-gpt-auto}
+      - AUTO_GENERATE_TAGS=${PAPERLESS_GPT_AUTO_GENERATE_TAGS:-true}
+      - AUTO_GENERATE_CORRESPONDENTS=${PAPERLESS_GPT_AUTO_CORRESPONDENT:-true}
+      - AUTO_GENERATE_DOCUMENT_TYPE=${PAPERLESS_GPT_AUTO_DOCUMENT_TYPE:-true}
     labels:
       - "traefik.enable=true"
       - "traefik.docker.network=t3_proxy"


### PR DESCRIPTION
## Problem

First real deploy of the `documents` stack. paperless-gpt v0.27.0 crash-looped:

```
fatal msg="Please set the LLM_PROVIDER environment variable."
```

## Cause

The compose was written against an older paperless-gpt env schema:

```yaml
- OPENAI_MODEL=${OPENAI_MODEL:-gpt-4o-mini}
- OPENAI_BASE_URL=${OPENAI_BASE_URL:-https://api.openai.com/v1}
```

Current paperless-gpt uses `LLM_PROVIDER` + `LLM_MODEL`, keeping `OPENAI_API_KEY` only as the
provider credential. `OPENAI_BASE_URL` is no longer read, so the commented "use a local LLM" hint
was stale too — replaced with the `LLM_PROVIDER=ollama` form pointing at the existing `ai-ollama`
container rather than the decommissioned Cerebro VM address.

`OPENAI_MODEL` is kept as the `.env`-facing name and mapped to `LLM_MODEL`, so no existing variable
needed renaming.

## Also in this PR

`.env.sample` updated to match, so the next person deploying this stack gets working defaults.

## Context

Related: paperless itself was pinned to `ghcr.io/paperless-ngx/paperless-ngx:v2.20.15`, a tag that
**does not exist** (`manifest unknown`, HTTP 404 on the registry — and paperless-ngx doesn't use a
`v` prefix). That is almost certainly why this stack had never been deployed. Fixed separately by
#242, which moved it to the real `3.0.4`.

## Verification

paperless-ngx v3.0.4 is now up and healthy — migrations applied, superuser created. Remaining
containers (`paperless_postgres`, `paperless_redis`, `paperless_gotenberg`, `paperless_tika`) all
healthy.