### PR TITLE
fix(renovate): move to renovate.json5 — "// key" comments were invalid config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -4,8 +4,18 @@
     "config:recommended"
   ],
   "pinDigests": false,
-  "// minimumReleaseAge": "REMOVED deliberately -- do not reinstate without reading this. It requires a release timestamp, which GHCR/quay/lscr/ECR do not reliably expose. When the age cannot be determined Renovate leaves the 'renovate/stability-days' status check PENDING FOREVER, not just for the configured window. Observed 2026-07-30: booklore v2.3.1 and d365fo-client v0.3.8 (both months old) reported 'Updates have not met minimum release age requirement'. That pending check makes every PR UNSTABLE, which blocks automerge, and under the default internalChecksFilter it also stopped the PRs being created at all -- 30 updates frozen on the Dependency Dashboard, 25 of them GHCR, while Docker Hub images flowed normally.",
-  "// internalChecksFilter": "Belt-and-braces alongside removing minimumReleaseAge: never withhold PR creation because an internal check cannot be satisfied.",
+  // minimumReleaseAge:
+  // REMOVED deliberately -- do not reinstate without reading this. It requires a release timestamp,
+  // which GHCR/quay/lscr/ECR do not reliably expose. When the age cannot be determined Renovate
+  // leaves the 'renovate/stability-days' status check PENDING FOREVER, not just for the configured
+  // window. Observed 2026-07-30: booklore v2.3.1 and d365fo-client v0.3.8 (both months old) reported
+  // 'Updates have not met minimum release age requirement'. That pending check makes every PR
+  // UNSTABLE, which blocks automerge, and under the default internalChecksFilter it also stopped the
+  // PRs being created at all -- 30 updates frozen on the Dependency Dashboard, 25 of them GHCR,
+  // while Docker Hub images flowed normally.
+  // internalChecksFilter:
+  // Belt-and-braces alongside removing minimumReleaseAge: never withhold PR creation because an
+  // internal check cannot be satisfied.
   "internalChecksFilter": "none",
   "enabledManagers": [
     "docker-compose",
@@ -475,7 +485,10 @@
       ]
     }
   ],
-  "// prConcurrentLimit": "Raised from the config:recommended default of 10. Major updates are automerge:false by design and sit open awaiting review; at a limit of 10 those permanently occupy slots and eventually block ALL other updates -- which is how the pipeline jammed in 2026-07.",
+  // prConcurrentLimit:
+  // Raised from the config:recommended default of 10. Major updates are automerge:false by design
+  // and sit open awaiting review; at a limit of 10 those permanently occupy slots and eventually
+  // block ALL other updates -- which is how the pipeline jammed in 2026-07.
   "prConcurrentLimit": 20,
   "prHourlyLimit": 6,
   "schedule": [


### PR DESCRIPTION
## Problem

Renovate has not run against this repo for ~2 hours. All 32 open PRs are stuck with stale pending
`renovate/stability-days` checks, and the "rebase all open PRs" checkbox on the Dependency Dashboard
has stayed ticked (Renovate resets it to `[ ]` only once processed).

## Cause — a regression I introduced in #214

I documented the config reasoning with a `"// <option>": "explanation"` convention. Renovate does
**not** support arbitrary top-level keys and rejects them:

```
ERROR: Found errors in configuration
  Invalid configuration option: // internalChecksFilter
  Invalid configuration option: // minimumReleaseAge
  Invalid configuration option: // prConcurrentLimit
```

A configuration error fails the entire repo run — so the fixes in #214 never actually took effect.

## Fix

`renovate.json` → **`renovate.json5`**, with the explanations as real `//` comments. Renovate
supports json5 natively.

This also clears the long-standing repository warning, which asked for precisely this:

> ⚠️ WARN: File contents are invalid JSONC but parse using JSON5. Support for this will be removed
> in a future release so please change to a support `.json5` file name or ensure correct JSON syntax.

## Verification

```
$ npx --package renovate@latest -c 'renovate-config-validator renovate.json5'
 INFO: Config validated successfully against 1 file(s)
```

Control-tested the validator against the old `"// key"` style to confirm it still flags it — so the
pass above is meaningful, not a false negative.

Content is semantically identical to the merged `renovate.json`:

| Check | Result |
|---|---|
| Top-level keys (minus `// ` keys) | identical |
| Differing values | none |
| packageRules | 39 → 39 |
| `internalChecksFilter` | `none` |
| `prConcurrentLimit` | `20` |
| `minimumReleaseAge` | absent |
| wrtag `allowedVersions` | `<0.30.0` |

Note the earlier `docker-compose.managerFilePatterns` validator error was an artifact of an old
renovate version being pulled by npx; `renovate@latest` accepts it.