### PR TITLE
fix(podsync): pin a current yt-dlp and give it a writable cache

### DIFF
--- a/stacks/selfhosted/podsync/compose.yaml
+++ b/stacks/selfhosted/podsync/compose.yaml
@@ -31,13 +31,39 @@ services:
       - 18080:8080  # HTTP port (host:container)
     networks:
       - t3_proxy
+    environment:
+      # yt-dlp caches the YouTube player JS under $HOME/.cache. The image sets HOME=/
+      # which uid 568 cannot write, producing
+      #   PermissionError: [Errno 13] Permission denied: '/.cache'
+      # and degrading nsig extraction ("Falling back to generic n function search").
+      # /app/db is a writable bind mount, so point HOME there.
+      - HOME=/app/db
     volumes:
       # Downloaded podcasts/videos
       - /mnt/fast/appdata/hoarder/podsync/downloads:/app/downloads:rw
-      # Database files
+      # Database files (also yt-dlp's HOME -> cache lives here)
       - /mnt/fast/appdata/hoarder/podsync/db:/app/db:rw
       # Config file
       - /mnt/fast/appdata/hoarder/podsync/config.toml:/app/config.toml:ro
+      # yt-dlp binary, managed by us -- see NOTE below.
+      #
+      # The image ships yt-dlp 2025.06.30 and podsync's `self_update` CANNOT work here:
+      # it needs to write into /usr/local/bin, which is not writable by uid 568, and it
+      # failed silently for ~13 months. YouTube's SABR rollout then broke that old
+      # version completely -- every download failed with
+      #   ERROR: [youtube] <id>: The following content is not available on this app.
+      # (792 such errors in 6h, 0 successful downloads).
+      #
+      # podsync v2.8.0 is the LATEST podsync release, so upgrading podsync does not help;
+      # the stale yt-dlp is the problem. self_update is now false in config.toml.
+      #
+      # REFRESH PERIODICALLY (YouTube breaks old yt-dlp regularly):
+      #   curl -sL -o /mnt/fast/appdata/hoarder/podsync/bin/yt-dlp \
+      #     https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_linux
+      #   chown 568:568 /mnt/fast/appdata/hoarder/podsync/bin/yt-dlp
+      #   chmod 755     /mnt/fast/appdata/hoarder/podsync/bin/yt-dlp
+      #   docker restart podsync
+      - /mnt/fast/appdata/hoarder/podsync/bin/yt-dlp:/usr/local/bin/youtube-dl:ro
     labels:
       - traefik.enable=true
       - traefik.http.routers.podsync.entrypoints=web,websecure


### PR DESCRIPTION
## Problem

Podsync had downloaded **nothing** for a long time. Every episode failed:

```
ERROR: [youtube] <id>: The following content is not available on this app.
```

**792 such errors in a 6-hour window, 0 successful downloads across 72 feed runs.** The feeds
themselves were healthy — podsync polled them, found the new items, and failed only at the download
step. That's why newly-added playlist videos never appeared.

## Cause 1 — yt-dlp was 13 months stale

The image ships yt-dlp **2025.06.30**. YouTube's SABR streaming rollout blocks it:

> WARNING: Some web client https formats have been skipped as they are missing a url.
> YouTube is forcing SABR streaming for this client.

Proven by A/B test on a video that had been failing:

| yt-dlp | Result |
|---|---|
| 2025.06.30 | `ERROR: The following content is not available on this app.` |
| 2026.07.04 | `What does you £99 get you? FSD in the UK features explained [1224s]` |

`self_update = true` was set but **never worked** — it must write into `/usr/local/bin`, which is not
writable by uid 568, and there is not a single self-update log entry. It failed silently for the
whole period. Now `false`, with the binary bind-mounted from appdata.

Note **podsync v2.8.0 is already the latest podsync release** — upgrading podsync would not have
fixed this. The stale bundled yt-dlp was the problem.

## Cause 2 — no writable cache

The image sets `HOME=/`, and the container runs as uid 568, so yt-dlp could not write its player-JS
cache:

```
PermissionError: [Errno 13] Permission denied: '/.cache'
```

which degraded nsig extraction (*"Falling back to generic n function search"*, *"nsig extraction
failed: Some formats may be missing"*). `HOME` now points at `/app/db`, an existing writable mount.

## Build choice matters

The image is **Alpine/musl** with Python 3.12.9, and the original `youtube-dl` is a `#!` Python
zipapp. The glibc standalone (`yt-dlp_linux`) will **not** run here — it fails with
`could not find youtube-dl: exit status 255`. Use the plain zipapp release asset.

## Verification

After deploying, the AI feed (ID3) downloaded **20 episodes**, including the exact IDs that had been
failing (`z6gWLY_ur8M`, `tzDDNWU21uQ`, `qrFpkbAZsBY`, `qIWpa582Pso`, `iXIuZLzj4RI`):

```
successfully downloaded file "z6gWLY_ur8M"
downloaded 20 episode(s)
```

Old SABR errors since the fix: **0**. Cache permission errors: **0**.

One remaining failure, `uIW8KgjreVw`, is a genuinely dead video ("This video is not available") — not
a config fault; it fails identically on a current yt-dlp.

## Tradeoff

The pinned binary needs periodic refresh, since YouTube breaks old yt-dlp regularly. The refresh
command is documented inline at the mount point.