### PR TITLE
feat(podsync): automate yt-dlp refresh + document why it is needed

### DIFF
--- a/stacks/selfhosted/podsync/README.md
+++ b/stacks/selfhosted/podsync/README.md
@@ -12,20 +12,61 @@ available).
 
 ## Feeds
 
-| ID | Title | Notes |
-|----|-------|-------|
-| `ID1` | Youtube Feeds | general |
-| `ID2` | Youtube Solar | |
-| `ID3` | Youtube AI | main feed; mixed AI + other content |
-| `ID4` | Youtube Notion | |
+| ID | Title | YouTube playlist | Notes |
+|----|-------|------------------|-------|
+| `ID1` | Youtube Feeds | Interesting Videos | general |
+| `ID2` | Youtube Solar | @solar | |
+| `ID3` | Youtube AI | @ai | main feed; mixed AI + other content |
+| `ID4` | Youtube Notion | @Notion | |
+| `ID5` | Youtube BBQ | BBQ | added 2026-08-11; `Arts`/`Food`, `explicit = false` |
 
 Each keeps the last 199 episodes (`clean = { keep_last = 199 }`) and prunes the oldest when new
 ones arrive — that is why episodes disappear over time. Feeds are `private_feed = true` so they
 are not indexed by podcast directories.
 
-Playlists are **unlisted**, not private. That matters: podsync authenticates with a plain YouTube
-Data API key, which can read unlisted playlists but *cannot* read genuinely private ones (those
-need OAuth or cookies, which podsync does not support).
+Subscribe at `https://podsync.deercrest.info/<FEED_ID>.xml`. Note the XML is only written when a
+feed cycle **completes**, so a newly added feed 404s until its first full run finishes — on a large
+playlist that can take an hour or more.
+
+### Playlists must be Unlisted, not Private
+
+podsync authenticates with a plain YouTube Data API **key**, which is anonymous: it can read public
+and unlisted playlists but **cannot** read genuinely private ones. Private playlists need OAuth 2.0
+(or cookies), and podsync supports neither — its only credential is `[tokens] youtube`.
+
+A private playlist fails at enumeration, so nothing downloads:
+
+```
+WARNING: [youtube:tab] YouTube said: ERROR - The caller does not have permission
+ERROR: [youtube:tab] <PLAYLIST_ID>: Unable to download API page: HTTP Error 403: Forbidden
+```
+
+This bit us with the BBQ playlist (`ID5`) on 2026-08-11 — it was set to Private and had to be
+flipped to Unlisted. Unlisted is not searchable and not shown on the channel; it only means
+"reachable with the 34-character playlist ID".
+
+To test a playlist before adding it:
+
+```bash
+docker exec podsync /usr/local/bin/youtube-dl --flat-playlist --no-warnings \
+  --print "%(playlist_title)s" --playlist-items 1 \
+  "https://www.youtube.com/playlist?list=<PLAYLIST_ID>"
+```
+
+It prints the playlist title if readable, or the 403 above if still private.
+
+### config.toml is not in this repo
+
+It lives only at `/mnt/fast/appdata/hoarder/podsync/config.toml` on LXC 100, because it contains
+the YouTube API key. Adding a feed is a host-side edit — back it up first, and validate before
+restarting:
+
+```bash
+cp -a config.toml config.toml.bak-$(date +%Y%m%d)
+python3 -c "import tomllib; print(list(tomllib.load(open('config.toml','rb'))['feeds'].keys()))"
+```
+
+Keep this table in sync when feeds are added.
 
 ---
 

--- a/stacks/selfhosted/podsync/README.md
+++ b/stacks/selfhosted/podsync/README.md
@@ -1,0 +1,175 @@
+# Podsync
+
+Turns YouTube playlists into podcast RSS feeds, so they can be subscribed to in Apple Podcasts and
+**downloaded for offline listening** (the primary use case here — playback where YouTube isn't
+available).
+
+- Web/RSS: <https://podsync.deercrest.info>
+- Feeds are served as `https://podsync.deercrest.info/<FEED_ID>.xml`
+- Config: `/mnt/fast/appdata/hoarder/podsync/config.toml` (**not** in this repo — contains the
+  YouTube API key)
+- Media: `/mnt/fast/appdata/hoarder/podsync/downloads/<FEED_ID>/`
+
+## Feeds
+
+| ID | Title | Notes |
+|----|-------|-------|
+| `ID1` | Youtube Feeds | general |
+| `ID2` | Youtube Solar | |
+| `ID3` | Youtube AI | main feed; mixed AI + other content |
+| `ID4` | Youtube Notion | |
+
+Each keeps the last 199 episodes (`clean = { keep_last = 199 }`) and prunes the oldest when new
+ones arrive — that is why episodes disappear over time. Feeds are `private_feed = true` so they
+are not indexed by podcast directories.
+
+Playlists are **unlisted**, not private. That matters: podsync authenticates with a plain YouTube
+Data API key, which can read unlisted playlists but *cannot* read genuinely private ones (those
+need OAuth or cookies, which podsync does not support).
+
+---
+
+## yt-dlp is managed by us — read this before touching it
+
+**podsync's `self_update` does not work here and is set to `false`.** Do not turn it back on.
+
+It must write into `/usr/local/bin`, which is not writable by uid 568. It failed **silently** for
+about 13 months — not a single log line. Meanwhile YouTube's SABR rollout blocked the stale
+bundled yt-dlp, and every single download failed:
+
+```
+ERROR: [youtube] <id>: The following content is not available on this app.
+```
+
+792 such errors in a 6-hour window, 0 successful downloads. The feeds looked healthy the whole
+time — podsync polled them and found new items, then failed only at the download step.
+
+Pulling a newer podsync image does **not** fix this either: podsync releases rarely (v2.8.0 was
+the latest release for over a year while the repo kept receiving commits), so the bundled yt-dlp
+stays old regardless.
+
+So the binary is bind-mounted from appdata and refreshed by us:
+
+```
+/mnt/fast/appdata/hoarder/podsync/bin/yt-dlp  ->  /usr/local/bin/youtube-dl (ro)
+```
+
+### Use the zipapp asset, not `yt-dlp_linux`
+
+The podsync image is **Alpine/musl with Python 3.12**. The `yt-dlp_linux` release asset is a
+glibc PyInstaller binary and **cannot execute there** — podsync crash-loops with:
+
+```
+could not find youtube-dl: failed to execute youtube-dl: exit status 255
+```
+
+Always use the plain `yt-dlp` zipapp asset (~3 MB, starts with `#!`). The updater script enforces
+this.
+
+### `HOME=/app/db`
+
+The image sets `HOME=/`, which uid 568 cannot write, so yt-dlp could not cache the YouTube player
+JS:
+
+```
+PermissionError: [Errno 13] Permission denied: '/.cache'
+```
+
+That degraded nsig extraction. `HOME` is set to `/app/db` (an existing writable mount) in
+`compose.yaml`.
+
+---
+
+## Scheduled update (systemd timer)
+
+YouTube breaks old yt-dlp regularly, so the refresh is automated. **This is the thing that keeps
+podsync working** — without it, downloads silently stop again.
+
+| Unit | Purpose |
+|------|---------|
+| `podsync-ytdlp-update.timer` | fires **Sundays 04:00** (+ up to 30m jitter), `Persistent=true` so a missed run catches up after downtime |
+| `podsync-ytdlp-update.service` | oneshot, runs `update-ytdlp.sh` |
+
+Both live in `/etc/systemd/system/` on LXC 100 (`172.16.1.159`) and call the script **from this
+repo** at `/mnt/fast/stacks/stacks/selfhosted/podsync/update-ytdlp.sh`, so the script is
+version-controlled here.
+
+`update-ytdlp.sh` is idempotent: it downloads the current yt-dlp and **only** installs and
+restarts podsync if the version actually changed. It refuses to install anything that isn't a
+`#!` zipapp or is implausibly small, so a truncated download or an HTML error page cannot brick
+the container.
+
+### Operating it
+
+```bash
+# status / when it next runs
+systemctl list-timers podsync-ytdlp-update.timer
+
+# run it now
+systemctl start podsync-ytdlp-update.service
+
+# logs (the script logs to stdout, captured by journald)
+journalctl -u podsync-ytdlp-update.service -n 50
+
+# disable temporarily
+systemctl disable --now podsync-ytdlp-update.timer
+```
+
+### Manual refresh (if the timer is off)
+
+```bash
+/mnt/fast/stacks/stacks/selfhosted/podsync/update-ytdlp.sh
+```
+
+### Reinstalling the units
+
+The unit files are not deployed by compose. If LXC 100 is rebuilt, recreate them — see
+`update-ytdlp.sh` header for context, and use `OnCalendar=Sun 04:00`, `Persistent=true`,
+`ExecStart` pointing at the repo path above.
+
+---
+
+## Troubleshooting
+
+**"Nothing new is downloading"** — check the download step, not the feed. Podsync will happily
+report a healthy feed cycle while every download fails:
+
+```bash
+docker logs podsync 2>&1 | grep -c "not available on this app"   # stale yt-dlp / YouTube block
+docker logs podsync 2>&1 | grep -c "Permission denied"           # cache not writable
+docker exec podsync /usr/local/bin/youtube-dl --version          # should be recent
+```
+
+If the count is high and the version is old, run the updater.
+
+**"This video is not available."** — different error, and usually genuine: the video was deleted,
+made private, or is region-blocked. Verify with a current yt-dlp before assuming a config fault.
+
+**JS runtime warning** — modern yt-dlp emits `No supported JavaScript runtime could be found`
+(deno). It is a deprecation warning, not a blocker; downloads still succeed. If YouTube tightens
+this, the image would need deno added.
+
+---
+
+## Filtering a mixed playlist
+
+`ID3` mixes AI and non-AI content. podsync supports per-feed regex filters, e.g.:
+
+```toml
+filters = { title = "(?i)(AI|LLM|GPT|Claude|agent)" }
+```
+
+`not_title` inverts it, so pointing a second feed at the same playlist with opposite filters
+splits one playlist into two podcasts. Duration and `max_age` filters are also available.
+
+## Alternatives considered (2026-08)
+
+Kept podsync — it is purpose-built for podcast feeds and the offline-archive requirement rules out
+streaming-only options.
+
+| Tool | Verdict |
+|------|---------|
+| **Pinchflat** | Bundles deno + supports cookies, but **~8 months without a release/commit**. For a yt-dlp-dependent tool that is the same staleness risk we just hit. |
+| **ytdl-sub** | Best-maintained (releases every few weeks). Real candidate if podsync stalls, but YAML/CLI config and podcast feeds are less first-class. |
+| **Vod2Pod-RSS** | Zero storage, transcodes on demand — **rejected**: no offline playback. |
+| **Tube Archivist / TubeSync** | Archive/media-server shaped, not podcast-feed shaped. |

--- a/stacks/selfhosted/podsync/compose.yaml
+++ b/stacks/selfhosted/podsync/compose.yaml
@@ -1,5 +1,11 @@
 # Podsync Stack - YouTube/Vimeo to podcast converter
 # Create RSS podcast feeds from video platforms
+#
+# SEE README.md IN THIS DIRECTORY before changing anything about yt-dlp.
+# Short version: podsync's `self_update` cannot work here (fails silently), the bundled yt-dlp
+# goes stale and YouTube then blocks every download. yt-dlp is bind-mounted from appdata and
+# refreshed weekly by the `podsync-ytdlp-update.timer` systemd timer on LXC 100, which runs
+# ./update-ytdlp.sh from this repo.
 
 name: podsync
 

--- a/stacks/selfhosted/podsync/update-ytdlp.sh
+++ b/stacks/selfhosted/podsync/update-ytdlp.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+#
+# Keep podsync's yt-dlp current.
+#
+# WHY THIS EXISTS
+#   podsync bundles yt-dlp in its image and offers `self_update`, but neither works here:
+#
+#     * self_update must write into /usr/local/bin, which is not writable by uid 568.
+#       It failed SILENTLY for ~13 months -- not one log line.
+#     * podsync releases rarely (v2.8.0 was the latest release for over a year while the
+#       repo kept getting commits), so pulling a newer image does not refresh yt-dlp either.
+#
+#   The result: yt-dlp went stale, YouTube's SABR rollout blocked it, and every download
+#   failed with "The following content is not available on this app." -- 792 errors in 6h,
+#   0 downloads. YouTube breaks old yt-dlp regularly, so this WILL recur without automation.
+#
+# WHAT IT DOES
+#   Downloads the current yt-dlp, and only if the version actually changed, installs it and
+#   restarts podsync. Safe to run repeatedly; a no-op when already current.
+#
+# IMPORTANT: must fetch the plain zipapp asset, NOT yt-dlp_linux.
+#   The podsync image is Alpine/musl with Python 3.12. The `yt-dlp_linux` standalone is a
+#   glibc PyInstaller binary and cannot execute there -- podsync crash-loops with
+#   "could not find youtube-dl: exit status 255".
+#
+set -euo pipefail
+
+BIN=/mnt/fast/appdata/hoarder/podsync/bin/yt-dlp
+URL=https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp   # zipapp, ~3MB
+CONTAINER=podsync
+OWNER=568:568
+
+log() { echo "$(date '+%F %T') :: update-ytdlp :: $*"; }
+
+tmp=$(mktemp /tmp/yt-dlp.XXXXXX)
+trap 'rm -f "$tmp"' EXIT
+
+current="none"
+[ -x "$BIN" ] && current=$("$BIN" --version 2>/dev/null | tail -1 || echo "unreadable")
+
+log "current version: $current"
+
+if ! curl -fsSL --max-time 120 -o "$tmp" "$URL"; then
+  log "ERROR: download failed; leaving existing binary untouched"
+  exit 1
+fi
+
+# Guard against a truncated download or an HTML error page being installed.
+if [ "$(head -c 2 "$tmp")" != '#!' ]; then
+  log "ERROR: downloaded file is not a '#!' zipapp (wrong asset or error page); aborting"
+  exit 1
+fi
+if [ "$(stat -c%s "$tmp")" -lt 1000000 ]; then
+  log "ERROR: downloaded file is implausibly small; aborting"
+  exit 1
+fi
+
+chmod 755 "$tmp"
+latest=$("$tmp" --version 2>/dev/null | tail -1 || echo "")
+if [ -z "$latest" ]; then
+  log "ERROR: downloaded binary does not report a version; aborting"
+  exit 1
+fi
+log "latest version:  $latest"
+
+if [ "$current" = "$latest" ]; then
+  log "already current -- no action"
+  exit 0
+fi
+
+install -o "${OWNER%:*}" -g "${OWNER#*:}" -m 755 "$tmp" "$BIN"
+log "installed $latest (was $current)"
+
+if docker ps --format '{{.Names}}' | grep -qx "$CONTAINER"; then
+  docker restart "$CONTAINER" >/dev/null
+  sleep 10
+  if docker ps --format '{{.Names}}' | grep -qx "$CONTAINER"; then
+    log "restarted $CONTAINER -- running"
+  else
+    log "WARNING: $CONTAINER did not come back after restart; check 'docker logs $CONTAINER'"
+    exit 1
+  fi
+else
+  log "note: $CONTAINER not running; binary updated, nothing to restart"
+fi
+
+log "done"


### PR DESCRIPTION
## Why

Follow-up to #258, which fixed podsync by hand. This stops it decaying again.

podsync's `self_update` **cannot work here** — it must write into `/usr/local/bin`, which uid 568
cannot. It failed **silently for ~13 months**. YouTube's SABR rollout then blocked the stale yt-dlp
and every download failed:

```
ERROR: [youtube] <id>: The following content is not available on this app.
```

792 errors in 6h, 0 downloads — while the feeds themselves looked perfectly healthy.

Pulling a newer podsync image does **not** help: podsync releases rarely (v2.8.0 was the latest
release for over a year while the repo kept getting commits), so the bundled yt-dlp stays old.

YouTube breaks old yt-dlp regularly, so #258's manual fix would simply decay again.

## What this adds

**`update-ytdlp.sh`** — idempotent updater. Installs and restarts podsync **only** when the version
actually changed. Refuses anything that isn't a `#!` zipapp or is implausibly small, so a truncated
download or an HTML error page can't brick the container.

It enforces the **zipapp** asset. The image is Alpine/musl with Python 3.12, so the glibc
`yt-dlp_linux` standalone cannot execute there — that mistake crash-loops podsync with
`could not find youtube-dl: exit status 255`.

**`README.md`** — feeds table; the unlisted-vs-private API-key constraint; why `self_update` is off
and must stay off; the `HOME=/app/db` cache fix; timer operation; troubleshooting (how to tell a
stale-yt-dlp block from a genuinely dead video); regex filtering for the mixed AI playlist; and the
alternatives comparison.

## Scheduling

systemd on LXC 100 — matching the existing `pulse-update.timer` convention and giving journald logs:

```
podsync-ytdlp-update.timer    Sun 04:00 (+30m jitter), Persistent=true
podsync-ytdlp-update.service  oneshot -> repo's update-ytdlp.sh
```

`Persistent=true` means a missed run catches up after downtime. The units call the script **from the
repo path**, so the logic stays version-controlled here; the unit files are documented in the README
for rebuild.

## Verification

Both paths tested on the live host:

| Case | Result |
|---|---|
| Already current | `already current -- no action`, container **not** restarted |
| Seeded 2025.06.30 | `installed 2026.07.04 (was 2025.06.30)`, restarted, confirmed running |

Timer installed and enabled — next run `Sun 2026-08-09 04:08`.

⚠️ **`systemd-analyze verify` currently reports the ExecStart path as missing** — expected, because
the script only exists in this branch. It resolves on merge + `git pull` on the host, well before
the first Sunday run. I deliberately did not hand-copy the script to that path, since an untracked
file there would make the host's `git pull` fail.