### PR TITLE
fix(dispatcharr): move host port to 9192 — 9191 is held by pulse-agent

### DIFF
--- a/NETWORK.md
+++ b/NETWORK.md
@@ -184,8 +184,34 @@ From the UniFi data, current naming patterns include:
 | cgate | 172.16.1.128 | pi | C-Bus gateway |
 | UCG Max | 172.16.1.1 | - | Network gateway |
 
+### Host-level services on LXC 100 (NOT Docker, NOT in `stacks/`)
+
+These run as **systemd services directly on the selfhost LXC**, so they do not appear in any
+compose file and `docker ps` will not show them. They still consume host ports — check here before
+assigning a new host port, or a container will fail to start.
+
+**Pulse** — Proxmox/Docker monitoring (`/opt/pulse`, v6.2.1, installed 2026-03-10)
+
+| Unit | Listens | Purpose |
+|------|---------|---------|
+| `pulse.service` | `*:7655` | Pulse server / web UI |
+| `pulse.service` | `127.0.0.1:9091` | internal |
+| `pulse-agent.service` | **`127.0.0.1:9191`** | agent health/metrics (`-health-addr`, empty disables) |
+
+The agent reports to `http://172.16.1.159:7655` with `--enable-host --enable-docker
+--enable-commands`, which is what provides host and container metrics. It self-updates via
+`pulse-auto-update.sh` + `pulse-update.timer`, so its version moves independently of this repo.
+
+⚠️ **`pulse-agent` owning 9191 silently blocked dispatcharr for ~6 weeks** (2026-06-30 →
+2026-08-11): the container sat in `created` state, never started, failing with `address already in
+use`. dispatcharr now publishes on host port **9192**. Do not reassign 9191.
+
+> Note: `docker ps` alone hides this class of failure — a container stuck in `created` is not
+> `running`, but is also not `exited`, `dead` or `restarting`. Use
+> `docker ps -a --format '{{.State}}' | sort | uniq -c` for a true census.
+
 ### Services by Host
-- **selfhost (159):** Traefik, Authelia, Sonarr, Radarr, Lidarr, Prowlarr, qBittorrent, Grafana, Dawarich, Open WebUI, Ollama, Immich, FreshRSS, and 60+ others
+- **selfhost (159):** Traefik, Authelia, Sonarr, Radarr, Lidarr, Prowlarr, qBittorrent, Grafana, Dawarich, Open WebUI, Ollama, Immich, FreshRSS, and 60+ others — plus host-level Pulse (above)
 - **cerebro (160):** Qdrant, Redis, SearXNG
 - **Home Assistant (31):** Home Assistant Core + addons
 - **zgate (135):** Z-Wave2MQTT, Zigbee2MQTT
@@ -194,6 +220,23 @@ From the UniFi data, current naming patterns include:
 ### Port Forwards
 - **443** → 172.16.1.159:443 (Traefik ingress)
 - **21115-21119** → 172.16.1.159:21115-21119 (Rustdesk)
+
+### Notable host ports on 172.16.1.159 (LXC 100)
+| Port | Owner | Notes |
+|------|-------|-------|
+| 7655 | `pulse.service` | Pulse web UI (host service, not Docker) |
+| 9091 | `pulse.service` | internal, localhost only |
+| **9191** | **`pulse-agent.service`** | **reserved — do not reassign** (see above) |
+| 9192 | dispatcharr (Docker) | → container 9191; Jellyfin tuner endpoint |
+| 8084 | sabnzbd (Docker) | |
+| 18080 | podsync (Docker) | |
+
+### TV / tuner chain
+HDHomeRun (**172.16.1.161**) + IPTV streams → **dispatcharr** (`http://172.16.1.159:9192`) →
+**Jellyfin** as a TV tuner source.
+
+Jellyfin must use the direct host port, **not** `dispatcharr.deercrest.info` — the Traefik route
+carries `chain-authelia@file` and would redirect a tuner client to a login page.
 
 ---
 

--- a/stacks/selfhosted/media/dispatcharr.yaml
+++ b/stacks/selfhosted/media/dispatcharr.yaml
@@ -43,7 +43,20 @@ services:
       t3_proxy:
       dispatcharr:
     ports:
-      - 9191:9191
+      # HOST PORT 9192, CONTAINER PORT 9191 -- do not "tidy" this back to 9191:9191.
+      #
+      # pulse-agent (the Pulse monitoring agent, a bare-metal systemd service on this LXC --
+      # NOT a compose stack) binds 127.0.0.1:9191 for its health/metrics endpoint. Publishing
+      # dispatcharr on 9191 therefore fails at container start with:
+      #   failed to bind host port 0.0.0.0:9191/tcp: address already in use
+      # The container sat in `created` state, never started, from 2026-06-30 to 2026-08-11
+      # because of this. See NETWORK.md -> "Host-level services on LXC 100".
+      #
+      # The host publish is deliberately kept (rather than relying on Traefik) because Jellyfin
+      # consumes dispatcharr as a TV tuner and the Traefik route carries chain-authelia@file,
+      # which would bounce a tuner client to a login page. Point Jellyfin and the HDHomeRun
+      # integration at http://172.16.1.159:9192.
+      - 9192:9191
     volumes:
       - /mnt/fast/appdata/media/dispatcharr/data:/data:rw  # Application config, recordings queue, and processing state
     environment:


### PR DESCRIPTION
## Problem

**dispatcharr has been down since 2026-06-30 (~6 weeks).** The container sat in `created` state and
had **never started once** (`StartedAt` = `0001-01-01`), failing with:

```
failed to bind host port 0.0.0.0:9191/tcp: address already in use
```

`pulse-agent` binds `127.0.0.1:9191` for its health/metrics endpoint. Pulse is a **bare-metal
systemd install** on LXC 100 — not a compose stack — so nothing in this repo recorded that it owns
that port. That's why the collision went unnoticed for six weeks.

## Why the host publish is kept (not replaced by Traefik)

Jellyfin consumes dispatcharr as a **TV tuner**, alongside the HDHomeRun at `172.16.1.161`. The
Traefik route carries `chain-authelia@file`, which would bounce a tuner client to a login page — so
a direct, unauthenticated host port is genuinely required here. Moved to **9192 → 9191** rather than
removed.

## Docs

`NETWORK.md` gains:

- **"Host-level services on LXC 100"** — documents Pulse (server `:7655`, agent health `:9191`,
  `127.0.0.1:9091`), that it self-updates via `pulse-update.timer` independently of this repo, and
  that its ports must be checked before assigning new ones
- a **notable host ports** table marking **9191 reserved**
- the **TV/tuner chain**: HDHomeRun + IPTV → dispatcharr `:9192` → Jellyfin

## Detection gap worth knowing

A container in `created` state is **not** `running`, but also **not** `exited`, `dead` or
`restarting` — so the usual `docker ps -a --filter status=...` checks miss it silently. This also
hid a second never-started container, `teleport`, which I've since started (now `Up`).

True census:

```bash
docker ps -a --format '{{.State}}' | sort | uniq -c
```

Documented in NETWORK.md.