### PR TITLE
docs(dispatcharr): correct the Jellyfin tuner endpoint to the macvlan address

### DIFF
--- a/NETWORK.md
+++ b/NETWORK.md
@@ -227,16 +227,32 @@ use`. dispatcharr now publishes on host port **9192**. Do not reassign 9191.
 | 7655 | `pulse.service` | Pulse web UI (host service, not Docker) |
 | 9091 | `pulse.service` | internal, localhost only |
 | **9191** | **`pulse-agent.service`** | **reserved — do not reassign** (see above) |
-| 9192 | dispatcharr (Docker) | → container 9191; Jellyfin tuner endpoint |
+| 9192 | dispatcharr (Docker) | → container 9191. Localhost only in practice (macvlan asymmetric routing) — **not** the Jellyfin endpoint; use `172.16.1.75:9191` |
 | 8084 | sabnzbd (Docker) | |
 | 18080 | podsync (Docker) | |
 
 ### TV / tuner chain
-HDHomeRun (**172.16.1.161**) + IPTV streams → **dispatcharr** (`http://172.16.1.159:9192`) →
-**Jellyfin** as a TV tuner source.
+HDHomeRun (**172.16.1.161**) + IPTV streams → **dispatcharr** → **Jellyfin** as a TV tuner source.
 
-Jellyfin must use the direct host port, **not** `dispatcharr.deercrest.info` — the Traefik route
-carries `chain-authelia@file` and would redirect a tuner client to a login page.
+**Use the macvlan address — `http://172.16.1.75:9191`.** Both dispatcharr and Jellyfin sit on
+`iot_macvlan` with real LAN IPs (dispatcharr `172.16.1.75`, Jellyfin `172.16.1.76`), and dispatcharr
+advertises that address itself:
+
+```json
+{"FriendlyName": "Dispatcharr HDHomeRun", "BaseURL": "http://172.16.1.75:9191/hdhr",
+ "LineupURL": "http://172.16.1.75:9191/hdhr/lineup.json"}
+```
+
+Verified from inside the Jellyfin container: `172.16.1.75:9191` → 200, and `/hdhr/discover.json`
+returns valid HDHomeRun JSON. `http://dispatcharr:9191` also works (shared `t3_proxy`).
+
+Do **not** use:
+- `dispatcharr.deercrest.info` — the Traefik route carries `chain-authelia@file` and would bounce a
+  tuner client to a login page.
+- `172.16.1.159:9192` (the host publish) — it answers on `127.0.0.1` from inside the LXC but **fails
+  from other hosts**. dispatcharr's default route goes out its macvlan interface, so replies to the
+  docker-proxy path are asymmetric and get dropped. The publish exists only as a legacy of the
+  original config; the macvlan address is the real endpoint.
 
 ---
 

--- a/stacks/selfhosted/media/dispatcharr.yaml
+++ b/stacks/selfhosted/media/dispatcharr.yaml
@@ -52,10 +52,15 @@ services:
       # The container sat in `created` state, never started, from 2026-06-30 to 2026-08-11
       # because of this. See NETWORK.md -> "Host-level services on LXC 100".
       #
-      # The host publish is deliberately kept (rather than relying on Traefik) because Jellyfin
-      # consumes dispatcharr as a TV tuner and the Traefik route carries chain-authelia@file,
-      # which would bounce a tuner client to a login page. Point Jellyfin and the HDHomeRun
-      # integration at http://172.16.1.159:9192.
+      # NOTE: this publish is largely vestigial. dispatcharr is on iot_macvlan with its own LAN
+      # IP (172.16.1.75), and that is the real endpoint -- dispatcharr advertises
+      # BaseURL http://172.16.1.75:9191/hdhr itself. The published port answers on 127.0.0.1
+      # from inside the LXC but FAILS from other hosts, because dispatcharr's default route goes
+      # out the macvlan interface and replies via the docker-proxy path are asymmetric.
+      #
+      # Point Jellyfin at http://172.16.1.75:9191 (verified from inside the jellyfin container),
+      # NOT at this port and NOT at dispatcharr.deercrest.info (that route has chain-authelia).
+      # Kept only because removing a published port is a separate change; it is harmless on 9192.
       - 9192:9191
     volumes:
       - /mnt/fast/appdata/media/dispatcharr/data:/data:rw  # Application config, recordings queue, and processing state


### PR DESCRIPTION
## Correcting my own error in #273

I documented the Jellyfin tuner endpoint as `http://172.16.1.159:9192` (the host publish). Testing
after deploy shows that is **wrong**.

## What's actually true

dispatcharr is attached to `iot_macvlan` with its own LAN IP — **`172.16.1.75`** — and it advertises
that address itself:

```json
{"FriendlyName": "Dispatcharr HDHomeRun",
 "BaseURL": "http://172.16.1.75:9191/hdhr",
 "LineupURL": "http://172.16.1.75:9191/hdhr/lineup.json"}
```

Verified **from inside the Jellyfin container**: `172.16.1.75:9191` → 200, and
`/hdhr/discover.json` returns valid HDHomeRun JSON. Jellyfin is itself on `iot_macvlan`
(`172.16.1.76`), so this is a direct LAN path — no proxying involved.

## The host publish doesn't work externally

| From | Target | Result |
|---|---|---|
| LXC 100 | `127.0.0.1:9192` | **200** |
| atlantis | `172.16.1.159:9192` | **000** (connection failed) |
| atlantis | `172.16.1.75:9191` | **200** |

dispatcharr's default route goes out the macvlan interface, so replies to the docker-proxy path are
asymmetric and get dropped. That's a known property of macvlan + published ports, not a
misconfiguration.

## What changes

Docs only — no functional change:

- `NETWORK.md` TV/tuner chain now specifies `http://172.16.1.75:9191`, with the discover.json
  evidence and an explicit "do not use" list (Traefik route → authelia bounce; host publish →
  asymmetric routing)
- the host-ports table marks 9192 as localhost-only in practice
- `dispatcharr.yaml` comment updated to match

The publish **stays** on 9192 — it's harmless, and reverting to 9191 would re-collide with
`pulse-agent`. It's simply documented as vestigial so nobody wires a client to it.