### PR TITLE
feat(buzz): add self-hosted Buzz relay stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # Selfhost Stacks
 
-Production-ready self-hosted infrastructure running on Proxmox, managed with Infrastructure as Code (Terraform) and GitOps workflows. Currently hosting 70+ containerized services across media streaming, home automation, development tools, and AI workloads.
+Production-ready self-hosted infrastructure running on Proxmox, managed with Infrastructure as Code (Terraform) and GitOps workflows. Currently hosting 90+ containerized services across media streaming, home automation, development tools, and AI workloads.
+
+> **Memory headroom is the binding constraint.** The host has ~29GB usable and typically runs at
+> 24–25GB. New stacks should set explicit `mem_limit` values rather than running unbounded.
+> (Corrected 2026-08-16: this README previously claimed 64GB. Actual is 32GB physical, ~29GB usable
+> after the Radeon 890M iGPU carve-out.)
 
 ## 🏗️ Architecture
 
@@ -13,7 +18,7 @@ This repository is split into two clean domains:
 
 | Resource | IP | Purpose | Specs |
 |----------|------------|---------|-------|
-| **Proxmox Host** | `172.16.1.158` | Type-1 hypervisor | AMD Ryzen AI 9 HX PRO 370, 64GB RAM, ZFS pool |
+| **Proxmox Host** | `172.16.1.158` | Type-1 hypervisor | AMD Ryzen AI 9 HX PRO 370 (24 cores), 32GB RAM (~29GB usable), ZFS pool |
 | **LXC 100** (`selfhost`) | `172.16.1.159` | Primary Docker runtime | Unprivileged LXC, GPU passthrough (AMD Radeon 890M) |
 | **VM 102** (`Cerebro`) | `172.16.1.160` | AI/ML workloads | Ubuntu 24.04, GPU passthrough, Ollama, OpenClaw |
 

--- a/stacks/selfhosted/buzz/.env.sample
+++ b/stacks/selfhosted/buzz/.env.sample
@@ -1,0 +1,55 @@
+# Buzz relay — copy to .env and fill. `.env` is gitignored (**/.env).
+#
+# WARNING: RELAY_URL is the community's identity, matched byte-for-byte by the
+# relay. A mismatch between this and what clients connect with is a NIP-98 401.
+# Changing it after members exist creates a NEW, EMPTY community. There is no
+# port in this URL.
+
+# ── Image ────────────────────────────────────────────────────────────────────
+# There is NO stable semver relay image. GHCR carries only main, latest, 0.1.0,
+# 0.3.20-rc.win.2 and ~95 sha-<7> tags. The desktop-v0.5.x GitHub releases are
+# the DESKTOP APP, not the relay. Always pin a sha-<7>.
+BUZZ_IMAGE=ghcr.io/block/buzz:sha-df9e773
+
+# ── Identity ─────────────────────────────────────────────────────────────────
+# Relay's own signing key (hex). Required for add-member to publish kind:13534.
+BUZZ_RELAY_PRIVATE_KEY=CHANGE_ME_64_HEX_PRIVATE_KEY
+# Owner pubkey — 64-char HEX, not npub. Owner outranks admin and is the only
+# role not settable via buzz-admin.
+RELAY_OWNER_PUBKEY=CHANGE_ME_OWNER_PUBKEY_HEX
+
+# ── Hostname-derived (these must all agree) ──────────────────────────────────
+RELAY_URL=wss://buzz.deercrest.info
+BUZZ_DOMAIN=buzz.deercrest.info
+BUZZ_MEDIA_BASE_URL=https://buzz.deercrest.info/media
+BUZZ_MEDIA_SERVER_DOMAIN=buzz.deercrest.info
+BUZZ_CORS_ORIGINS=https://buzz.deercrest.info
+# Pairing relay gets its OWN hostname, and the scheme MUST be ws:// or wss://
+# (the relay refuses to start otherwise). A separate host avoids path rewriting:
+# upstream's Caddy example uses `handle_path /pair*`, which STRIPS the prefix,
+# and Cloudflare Tunnel ingress cannot strip paths.
+BUZZ_PAIRING_RELAY_URL=wss://pair.deercrest.info
+
+# ── Relay behaviour ──────────────────────────────────────────────────────────
+BUZZ_REQUIRE_AUTH_TOKEN=true
+BUZZ_REQUIRE_RELAY_MEMBERSHIP=true
+BUZZ_ALLOW_NIP_OA_AUTH=true
+BUZZ_AUTO_MIGRATE=true
+BUZZ_GIT_CONFORMANCE_PROBE=true
+RUST_LOG=buzz_relay=info,buzz_db=info,buzz_auth=info,buzz_pubsub=info,tower_http=info
+
+# ── Secrets (generate with: openssl rand -hex 32) ────────────────────────────
+BUZZ_GIT_HOOK_HMAC_SECRET=CHANGE_ME_RANDOM_64_HEX
+POSTGRES_DB=buzz
+POSTGRES_USER=buzz
+POSTGRES_PASSWORD=CHANGE_ME_RANDOM_PASSWORD
+REDIS_PASSWORD=CHANGE_ME_RANDOM_PASSWORD
+BUZZ_S3_ACCESS_KEY=CHANGE_ME_RANDOM_ACCESS_KEY
+BUZZ_S3_SECRET_KEY=CHANGE_ME_RANDOM_SECRET_KEY
+BUZZ_S3_BUCKET=buzz-media
+BUZZ_S3_ADDRESSING_STYLE=path
+
+# ── Local debug port (loopback only) ─────────────────────────────────────────
+# Public ingress is cloudflared over buzz-net. 3000/3001/3002 are taken on this
+# host, hence 3080. Never bind this to 0.0.0.0.
+BUZZ_DEBUG_PORT=3080

--- a/stacks/selfhosted/buzz/README.md
+++ b/stacks/selfhosted/buzz/README.md
@@ -1,0 +1,123 @@
+# Buzz — self-hosted relay
+
+> **Stack:** Buzz relay (pinned `sha-df9e773`) · Postgres 17-alpine · Redis 7 · MinIO · pairing sidecar
+> **Host:** LXC `100` (`selfhost`) at `172.16.1.159`
+> **Public:** `buzz.deercrest.info` + `pair.deercrest.info` via a dedicated Cloudflare Tunnel
+> **Upstream:** [block/buzz](https://github.com/block/buzz) (Apache-2.0)
+
+[Buzz](https://github.com/block/buzz) is Block's Nostr-based community chat, where humans and AI
+agents share a channel as first-class members. This deployment serves the Deer Crest family plus one
+resident agent, **DATA**, running headless on the Mac Mini.
+
+Full deployment brief and design record live in the neocortex vault at
+`clients/deer-crest/buzz_ai/`.
+
+---
+
+## Why this differs from upstream's compose
+
+Upstream ships `deploy/compose/compose.yml`. This is vendored from it with four deliberate changes.
+
+**Bind mounts, not named volumes.** Named Docker volumes land in `/var/lib/docker` on the LXC's
+128 G root disk. The ZFS datasets do not:
+
+| Path | Dataset | Holds |
+|---|---|---|
+| `/mnt/fast/appdata/buzz/{postgres,redis,git}` | `fast/appdata/buzz` | app data — 1.29 T avail |
+| `/mnt/tank/buzz/minio` | `tank/buzz` | chat media — 9.07 T avail |
+
+Media goes on `tank` because it is the growth-prone, irreplaceable part (family photos and video).
+Directory ownership is per-service and **not** uniform — see the table below.
+
+**No published host port.** Ports 3000–3002 are already in use here, and upstream's
+`"${BUZZ_HTTP_PORT:-3000}:3000"` binds `0.0.0.0`, exposing the relay to the whole LAN. `cloudflared`
+joins `buzz-net` and addresses `relay:3000` directly. Only a loopback debug port is published.
+
+**A pairing sidecar that upstream omits.** The relay advertises NIP-43, so desktop clients expect a
+pairing endpoint. Upstream's compose has no `buzz-pair-relay` service, so pairing fails and **no phone
+can be onboarded at all** — reported three times upstream (#2734, #3291, #3842).
+It must use `entrypoint:`; Compose's `command:` silently runs the relay binary instead.
+
+The sidecar gets its **own hostname** rather than a `/pair` path on the relay host:
+
+| Hostname | Target |
+|---|---|
+| `buzz.deercrest.info` | `relay:3000` |
+| `pair.deercrest.info` | `pairing-relay:5000` |
+
+Upstream's Caddy example proxies `/pair` with `handle_path`, which **strips the prefix**. Cloudflare
+Tunnel ingress cannot strip paths, so a same-host `/pair` route would forward the prefix and break
+pairing. Upstream's own Helm test uses a separate host too (`pairingRelay.url: wss://pairing.buzz.xyz`).
+
+`BUZZ_PAIRING_RELAY_URL` **must** be `ws://` or `wss://` — the relay validates the scheme at startup
+and refuses to boot on `https://`. It is advertised as `pairing_relay_url` in the NIP-11 document.
+
+**A pinned image.** There is no stable semver relay image — GHCR carries `main`, `latest`, `0.1.0`,
+`0.3.20-rc.win.2` and ~95 `sha-<7>` tags. The `desktop-v0.5.x` GitHub releases are the *desktop app*,
+not the relay. `sha-df9e773` was chosen by matching the `main` tag's digest.
+
+---
+
+## Directory ownership
+
+Each service runs as a different uid. Getting this wrong shows up as a container that restart-loops
+on first boot.
+
+| Path | Owner | Why |
+|---|---|---|
+| `/mnt/fast/appdata/buzz/postgres` | `70:70` | `postgres:17-**alpine**` runs as uid 70 — **not** 999 like the Debian image other stacks use |
+| `/mnt/fast/appdata/buzz/redis` | `999:1000` | `redis:7-alpine` |
+| `/mnt/fast/appdata/buzz/git` | `1000:1000` | relay runs as `buzz:buzz` |
+| `/mnt/tank/buzz/minio` | `0:0` | the MinIO image declares no user |
+
+---
+
+## Operating
+
+```bash
+cd /mnt/fast/stacks/stacks/selfhosted/buzz
+
+docker compose up -d --wait          # start
+docker compose ps                    # status
+docker compose logs -f relay         # logs
+curl -fsS http://127.0.0.1:3080/_liveness
+
+# membership (buzz-admin lives in the relay image)
+docker compose exec relay /usr/local/bin/buzz-admin list-members
+docker compose exec relay /usr/local/bin/buzz-admin add-member --pubkey <npub-or-hex> --role member
+```
+
+> **Adding several members: `sleep 1` between each.** The roster is a single replaceable
+> **kind:13534** event, so two adds landing in the same second silently drop a member. Never
+> parallelise (no `xargs -P`), and assert the final count with `list-members`.
+
+Roles are `owner | admin | member`. `owner` comes solely from `RELAY_OWNER_PUBKEY` and outranks
+admin; `buzz-admin` refuses `--role owner`. Only the owner can change roles (kind 9032).
+
+---
+
+## Backups
+
+The relay private key and the Postgres database **must be backed up and restored together**. A
+restored database paired with a fresh relay key is a different relay, and every previously signed
+event stops verifying.
+
+Back up: `BUZZ_RELAY_PRIVATE_KEY`, Postgres, the MinIO bucket, `/mnt/fast/appdata/buzz/git`, and the
+owner key. `docker compose exec relay /usr/local/bin/buzz-admin --help` and upstream's
+`run.sh backup-hint` enumerate the same five.
+
+---
+
+## Known upstream issues affecting this deployment
+
+| # | Issue |
+|---|---|
+| #2734 / #3291 / #3842 | No pairing sidecar in compose → `/pair` 404s (mitigated here) |
+| #2935 | Imported nsec may not become the active identity against a self-hosted relay |
+| #5197 | Desktop WebSocket ignores the OS trust store; fails silently behind a private CA |
+| #3471 | GUI installs a `buzz` wrapper that shadows the real CLI — sends return exit 0 and do nothing |
+| #5484 / #3776 | Agent `kind:10100` discoverability quirks; the `buzz` CLI cannot publish that kind |
+
+**iOS has no push notifications** — no APNs entitlement, badge-only authorization, and the NIP-PL
+client half is unwritten. Messages arrive only when the app is opened. This is a property of the
+software, not of this deployment.

--- a/stacks/selfhosted/buzz/compose.yaml
+++ b/stacks/selfhosted/buzz/compose.yaml
@@ -1,0 +1,168 @@
+# Buzz — self-hosted relay for the Deer Crest family community
+#
+# Upstream: github.com/block/buzz (Apache-2.0, Block Inc.)
+# Vendored from deploy/compose/compose.yml and adapted to estate conventions:
+#   - bind mounts under /mnt/fast + /mnt/tank instead of named Docker volumes
+#     (named volumes live on the 128G LXC root disk; these datasets do not)
+#   - no published host port — cloudflared joins buzz-net and addresses `relay`
+#     directly (ports 3000/3001/3002 are already taken on this host anyway)
+#   - pairing-relay sidecar added; upstream ships none, so /pair 404s and phones
+#     cannot onboard at all (upstream #2734, #3291, #3842)
+#
+# RELAY_URL is the community's identity, matched byte-for-byte. Changing it
+# creates a new, empty community. Do not change it after members are added.
+
+name: buzz
+
+networks:
+  buzz-net:
+    driver: bridge
+    name: buzz-net
+    labels:
+      com.buzz.network: production
+
+services:
+
+  relay:
+    container_name: buzz-relay
+    image: ${BUZZ_IMAGE}
+    restart: unless-stopped
+    env_file: .env
+    environment:
+      BUZZ_BIND_ADDR: 0.0.0.0:3000
+      BUZZ_HEALTH_PORT: "8080"
+      BUZZ_METRICS_PORT: "9102"
+      DATABASE_URL: postgres://${POSTGRES_USER:-buzz}:${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD}@buzz-postgres:5432/${POSTGRES_DB:-buzz}
+      REDIS_URL: redis://:${REDIS_PASSWORD:?set REDIS_PASSWORD}@buzz-redis:6379
+      BUZZ_S3_ENDPOINT: http://buzz-minio:9000
+      # Docker DNS resolves `buzz-minio`, not arbitrary `<bucket>.buzz-minio` hosts.
+      BUZZ_S3_ADDRESSING_STYLE: path
+      BUZZ_S3_ACCESS_KEY: ${BUZZ_S3_ACCESS_KEY:?set BUZZ_S3_ACCESS_KEY}
+      BUZZ_S3_SECRET_KEY: ${BUZZ_S3_SECRET_KEY:?set BUZZ_S3_SECRET_KEY}
+      BUZZ_S3_BUCKET: ${BUZZ_S3_BUCKET:-buzz-media}
+      BUZZ_GIT_REPO_PATH: /data/git
+      BUZZ_AUTO_MIGRATE: ${BUZZ_AUTO_MIGRATE:-false}
+      BUZZ_GIT_CONFORMANCE_PROBE: ${BUZZ_GIT_CONFORMANCE_PROBE:-true}
+    # Loopback only — for local liveness checks and debugging. Public ingress is
+    # cloudflared over buzz-net, NOT this port. Never bind 0.0.0.0 here.
+    ports:
+      - "127.0.0.1:${BUZZ_DEBUG_PORT:-3080}:3000"
+    volumes:
+      - /mnt/fast/appdata/buzz/git:/data/git
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+      minio-init:
+        condition: service_completed_successfully
+    # Probes /_readiness over /dev/tcp because the runtime image has bash but no curl/wget.
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "bash -ec 'exec 3<>/dev/tcp/127.0.0.1/8080; printf \"GET /_readiness HTTP/1.1\\r\\nHost: 127.0.0.1\\r\\nConnection: close\\r\\n\\r\\n\" >&3; grep -q \"200 OK\" <&3'",
+        ]
+      interval: 10s
+      timeout: 3s
+      retries: 12
+      start_period: 30s
+    networks:
+      - buzz-net
+
+  # NIP-43 pairing sidecar. Upstream's compose omits this, so the relay advertises
+  # pairing while /pair returns 404 and every phone fails to onboard.
+  # MUST be `entrypoint:` — Compose `command:` silently runs the relay binary instead.
+  pairing-relay:
+    container_name: buzz-pairing-relay
+    image: ${BUZZ_IMAGE}
+    restart: unless-stopped
+    entrypoint: ["/usr/local/bin/buzz-pair-relay"]
+    env_file: .env
+    depends_on:
+      relay:
+        condition: service_healthy
+    networks:
+      - buzz-net
+
+  postgres:
+    container_name: buzz-postgres
+    image: postgres:17-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-buzz}
+      POSTGRES_USER: ${POSTGRES_USER:-buzz}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD}
+      PGDATA: /var/lib/postgresql/data/pgdata
+    volumes:
+      # host dir is uid 70 — postgres:17-ALPINE runs as 70, not 999 like the Debian image
+      - /mnt/fast/appdata/buzz/postgres:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
+    networks:
+      - buzz-net
+
+  redis:
+    container_name: buzz-redis
+    image: redis:7-alpine
+    restart: unless-stopped
+    command: ["redis-server", "--appendonly", "yes", "--requirepass", "${REDIS_PASSWORD:?set REDIS_PASSWORD}"]
+    environment:
+      REDIS_PASSWORD: ${REDIS_PASSWORD:?set REDIS_PASSWORD}
+    volumes:
+      - /mnt/fast/appdata/buzz/redis:/data
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli -a \"$${REDIS_PASSWORD}\" ping | grep -q PONG"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+      start_period: 5s
+    networks:
+      - buzz-net
+
+  # Object store for chat media. On tank, not fast: this is the growth-prone,
+  # irreplaceable data (family photos and video shared in channels).
+  minio:
+    container_name: buzz-minio
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
+    restart: unless-stopped
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: ${BUZZ_S3_ACCESS_KEY:?set BUZZ_S3_ACCESS_KEY}
+      MINIO_ROOT_PASSWORD: ${BUZZ_S3_SECRET_KEY:?set BUZZ_S3_SECRET_KEY}
+    volumes:
+      - /mnt/tank/buzz/minio:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:9000/minio/health/live"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
+    networks:
+      - buzz-net
+
+  minio-init:
+    container_name: buzz-minio-init
+    image: minio/mc:RELEASE.2025-08-13T08-35-41Z
+    restart: "no"
+    depends_on:
+      minio:
+        condition: service_healthy
+    environment:
+      BUZZ_S3_ACCESS_KEY: ${BUZZ_S3_ACCESS_KEY:?set BUZZ_S3_ACCESS_KEY}
+      BUZZ_S3_SECRET_KEY: ${BUZZ_S3_SECRET_KEY:?set BUZZ_S3_SECRET_KEY}
+      BUZZ_S3_BUCKET: ${BUZZ_S3_BUCKET:-buzz-media}
+    entrypoint: >
+      /bin/sh -euc '
+        mc alias set local http://buzz-minio:9000 "$${BUZZ_S3_ACCESS_KEY}" "$${BUZZ_S3_SECRET_KEY}"
+        mc mb --ignore-existing "local/$${BUZZ_S3_BUCKET}"
+        mc anonymous set none "local/$${BUZZ_S3_BUCKET}"
+      '
+    networks:
+      - buzz-net

--- a/stacks/selfhosted/buzz/compose.yaml
+++ b/stacks/selfhosted/buzz/compose.yaml
@@ -11,6 +11,10 @@
 #
 # RELAY_URL is the community's identity, matched byte-for-byte. Changing it
 # creates a new, empty community. Do not change it after members are added.
+#
+# MEMORY: this host has ~29GB usable and typically sits at 24-25GB, so every
+# service here is capped. Total ceiling ~2GB. These are first-pass numbers --
+# measure actual usage with `docker stats` and tighten or raise them.
 
 name: buzz
 
@@ -25,6 +29,7 @@ services:
 
   relay:
     container_name: buzz-relay
+    mem_limit: 512m
     image: ${BUZZ_IMAGE}
     restart: unless-stopped
     env_file: .env
@@ -77,10 +82,41 @@ services:
   # MUST be `entrypoint:` — Compose `command:` silently runs the relay binary instead.
   pairing-relay:
     container_name: buzz-pairing-relay
+    mem_limit: 128m
     image: ${BUZZ_IMAGE}
     restart: unless-stopped
     entrypoint: ["/usr/local/bin/buzz-pair-relay"]
     env_file: .env
+    environment:
+      # Defaults to 127.0.0.1:5000 — loopback only, so cloudflared gets a 502.
+      # Upstream's Helm chart sets this; their compose never does, because it
+      # ships no pairing sidecar at all.
+      BUZZ_PAIR_RELAY_BIND_ADDR: 0.0.0.0:5000
+    depends_on:
+      relay:
+        condition: service_healthy
+    networks:
+      - buzz-net
+
+  # Public ingress. Outbound-only tunnel to the Cloudflare edge — no port-forward,
+  # no exposed origin IP. Remotely-managed (config_src: cloudflare): the ingress
+  # rules live on the tunnel itself, not in a local config file.
+  #
+  #   buzz.deercrest.info -> http://buzz-relay:3000
+  #   pair.deercrest.info -> http://buzz-pairing-relay:5000
+  #   everything else     -> 404 (default deny)
+  #
+  # Because cloudflared sits on buzz-net it addresses the containers directly,
+  # which is why the relay needs no published host port.
+  cloudflared:
+    container_name: buzz-cloudflared
+    mem_limit: 128m
+    # renovate: datasource=docker depName=cloudflare/cloudflared
+    image: cloudflare/cloudflared:2026.8.2
+    restart: unless-stopped
+    command: tunnel --no-autoupdate run
+    environment:
+      TUNNEL_TOKEN: ${TUNNEL_TOKEN:?set TUNNEL_TOKEN}
     depends_on:
       relay:
         condition: service_healthy
@@ -89,6 +125,7 @@ services:
 
   postgres:
     container_name: buzz-postgres
+    mem_limit: 512m
     image: postgres:17-alpine
     restart: unless-stopped
     environment:
@@ -110,9 +147,11 @@ services:
 
   redis:
     container_name: buzz-redis
+    mem_limit: 256m
     image: redis:7-alpine
     restart: unless-stopped
-    command: ["redis-server", "--appendonly", "yes", "--requirepass", "${REDIS_PASSWORD:?set REDIS_PASSWORD}"]
+    # maxmemory sits under mem_limit so redis evicts rather than being OOM-killed
+    command: ["redis-server", "--appendonly", "yes", "--requirepass", "${REDIS_PASSWORD:?set REDIS_PASSWORD}", "--maxmemory", "200mb", "--maxmemory-policy", "noeviction"]
     environment:
       REDIS_PASSWORD: ${REDIS_PASSWORD:?set REDIS_PASSWORD}
     volumes:
@@ -130,6 +169,7 @@ services:
   # irreplaceable data (family photos and video shared in channels).
   minio:
     container_name: buzz-minio
+    mem_limit: 512m
     image: minio/minio:RELEASE.2025-09-07T16-13-09Z
     restart: unless-stopped
     command: server /data --console-address ":9001"


### PR DESCRIPTION
Adds `stacks/selfhosted/buzz/` — a self-hosted [Buzz](https://github.com/block/buzz) relay (Nostr-based community chat) for the family, plus a headless agent seat on the Mac Mini.

**Live and verified** on `selfhost` before opening this PR: 6/6 containers healthy, 61 migrations applied, NIP-11 advertising NIP-42 + NIP-43, roster correctly closed with owner only.

## Vendored, with four deliberate changes

Upstream ships `deploy/compose/compose.yml`. Each change below fixes something that would break on this host:

| Change | Why |
|---|---|
| Bind mounts on ZFS datasets | Named volumes land in `/var/lib/docker` on the **128 G LXC root disk**. New `fast/appdata/buzz` + `tank/buzz`, hot-plugged as `mp29`/`mp30` — **no restart** of the other 97 containers |
| No published host port | 3000–3002 are taken, and upstream binds `0.0.0.0`, exposing the relay LAN-wide. `cloudflared` will join `buzz-net`. Loopback `3080` for debug only |
| Pairing sidecar added | Relay advertises NIP-43 but upstream's compose has no `buzz-pair-relay`, so pairing fails and **no phone can onboard** (#2734, #3291, #3842) |
| Image pinned `sha-df9e773` | No semver relay image exists — `desktop-v0.5.x` is the desktop app. Digest matches the `main` tag |

## Two traps worth knowing

**`postgres:17-alpine` runs as uid 70**, not 999 like the Debian image `keeper-sh` and `immich` use. Copying that convention restart-loops Postgres on first boot. Ownership is per-service and documented.

**The pairing sidecar needs its own hostname.** Upstream's Caddy example proxies `/pair` with `handle_path`, which *strips* the prefix; Cloudflare Tunnel ingress cannot strip paths. Upstream's own Helm test uses a separate host too.

```
buzz.deercrest.info  ->  relay:3000
pair.deercrest.info  ->  pairing-relay:5000
```

`BUZZ_PAIRING_RELAY_URL` must be `ws://`/`wss://` — the relay validates the scheme at boot and crash-loops on `https://`.

Also: the sidecar must use `entrypoint:`; Compose's `command:` silently runs the relay binary instead.

## Not in this PR

`cloudflared` (Phase 4) — needs a Cloudflare credential and two DNS records. The stack currently has no public ingress.

## Known upstream limitation

**iOS has no push notifications** — no APNs entitlement, badge-only authorization, NIP-PL client half unwritten. A property of the software, not this deployment. Documented in the README.