### PR TITLE
feat(dispatcharr): add XC endpoint for off-LAN TV clients

### DIFF
--- a/NETWORK.md
+++ b/NETWORK.md
@@ -232,7 +232,18 @@ use`. dispatcharr now publishes on host port **9192**. Do not reassign 9191.
 | 18080 | podsync (Docker) | |
 
 ### TV / tuner chain
-HDHomeRun (**172.16.1.161**) + IPTV streams → **dispatcharr** → **Jellyfin** as a TV tuner source.
+HDHomeRun (**172.16.1.161**) + IPTV streams → **dispatcharr** → two independent consumers:
+
+| Consumer | Path | Protocol |
+|---|---|---|
+| Jellyfin (Deer Crest) | `172.16.1.75:9191/hdhr` + `/output/epg` | HDHR tuner + XMLTV |
+| TiviMate (Fosse Road TV) | `172.16.1.75:9191` over **Tailscale** | Xtream Codes (`fosse-tv`) |
+
+Jellyfin is for the media library; **TiviMate is the live-TV client**. Jellyfin's Live TV path
+adds ~7.7s to every channel change (3s ffprobe + 3s HLS segment build + ~1s tuner connect) and
+that is inherent to how it does Live TV — not tunable. TiviMate plays the MPEG-TS natively and
+switches in roughly the ~1.1s dispatcharr actually needs. Since 2026-08-14 the physical
+HDHomeRun is **no longer a direct Jellyfin tuner** — dispatcharr is the single source.
 
 **Use the macvlan address — `http://172.16.1.75:9191`.** Both dispatcharr and Jellyfin sit on
 `iot_macvlan` with real LAN IPs (dispatcharr `172.16.1.75`, Jellyfin `172.16.1.76`), and dispatcharr
@@ -245,6 +256,25 @@ advertises that address itself:
 
 Verified from inside the Jellyfin container: `172.16.1.75:9191` → 200, and `/hdhr/discover.json`
 returns valid HDHomeRun JSON. `http://dispatcharr:9191` also works (shared `t3_proxy`).
+
+#### Off-LAN clients (Fosse Road)
+
+`tv.deercrest.info` is a **second Traefik router with no authelia**, allow-listing only the XC
+paths (`/player_api.php`, `/panel_api.php`, `/get.php`, `/xmltv.php`, `/live/`, `/timeshift/`,
+`/streaming/`, `/api/channels/logos/`) plus a 30/min rate limit. Everything else on that host
+404s. It is the **one grey-cloud record** in the estate — Cloudflare's proxy breaks long-lived
+MPEG-TS — so it publishes the origin IP. It exists only as a fallback; the TV normally reaches
+dispatcharr over Tailscale and this route can be retired.
+
+dispatcharr's own `network_access` ACLs are the second layer, and they are effective because
+`get_client_ip` trusts `X-Forwarded-For` from private-range proxies (Traefik), so the **real**
+client IP is evaluated:
+
+| Key | Value | Why |
+|---|---|---|
+| `M3U_EPG` | private ranges **+ `100.64.0.0/10`** | `/output/*` has no auth of its own. The Tailscale CGNAT range must be listed explicitly or tailnet clients get 403 |
+| `XC_API` / `STREAMS` | `0.0.0.0/0` | needed by the off-LAN TV; auth is the XC credential |
+| `UI` | `0.0.0.0/0` | do **not** restrict to LAN — it would lock out remote admin via the Traefik route |
 
 Do **not** use:
 - `dispatcharr.deercrest.info` — the Traefik route carries `chain-authelia@file` and would bounce a

--- a/stacks/selfhosted/media/dispatcharr.yaml
+++ b/stacks/selfhosted/media/dispatcharr.yaml
@@ -101,5 +101,54 @@ services:
       - traefik.http.routers.dispatcharr.service=dispatcharr-svc
       - traefik.http.services.dispatcharr-svc.loadbalancer.server.port=9191
 
+      # --- tv.deercrest.info : Xtream Codes endpoint for off-LAN TV clients ---
+      #
+      # The Samsung Tizen TV at Fosse Road is not on Tailscale, so it needs a public
+      # endpoint. It CANNOT use dispatcharr.deercrest.info -- that router carries
+      # chain-authelia, and an IPTV player has no browser to complete an auth flow.
+      #
+      # This router therefore has NO authelia. Authentication is the XC credential
+      # (user `fosse-tv` + custom_properties.xc_password, a dispatcharr STREAMER-level
+      # account capped at stream_limit=1). Two things keep that acceptable:
+      #
+      #   1. The rule allow-lists ONLY the XC paths below. Anything else on this host
+      #      matches no router and Traefik returns 404 -- default-deny. In particular
+      #      /output/m3u, /output/epg and /hdhr are NOT reachable here; those carry no
+      #      auth of their own and are additionally pinned to private ranges via
+      #      dispatcharr's own network_access.M3U_EPG ACL.
+      #   2. /api/ is deliberately narrowed to /api/channels/logos/ -- channel icons are
+      #      unauthenticated PNGs and the TV needs them. The rest of /api/ (the admin
+      #      surface) 401s anyway, but it is not exposed here regardless.
+      #
+      # XC puts username+password in the query string / URL path, so they WILL appear in
+      # Traefik access logs, and there is no lockout on failed XC auth -- hence the rate
+      # limit below. Rotate the xc_password if those logs are ever shared.
+      #
+      # DNS: this record MUST be grey-cloud (DNS-only), which makes it the ONE exception
+      # in this estate -- dispatcharr.deercrest.info and jellyfin.deercrest.info are both
+      # orange-clouded (they resolve to 172.67.x / 104.21.x). It cannot be proxied because
+      # Cloudflare's proxy breaks long-lived MPEG-TS (100s timeout) and serving video
+      # through the free tier is against their ToS.
+      #
+      # TRADE-OFF, accept before deploying: grey-cloud publishes the home origin IP in
+      # public DNS, losing the origin-hiding the other records get. If that is not
+      # acceptable, the alternative is the Tailscale subnet-router option (a travel
+      # router at Fosse Road), which exposes nothing at all.
+      #
+      # (dns-cloudflare on the cert resolver is DNS-01 for issuance only -- unaffected
+      # by the record being grey-clouded.)
+      - traefik.http.routers.dispatcharr-tv.entrypoints=websecure
+      - traefik.http.routers.dispatcharr-tv.rule=Host(`tv.deercrest.info`) && (PathPrefix(`/player_api.php`) || PathPrefix(`/panel_api.php`) || PathPrefix(`/get.php`) || PathPrefix(`/xmltv.php`) || PathPrefix(`/live/`) || PathPrefix(`/timeshift/`) || PathPrefix(`/streaming/`) || PathPrefix(`/api/channels/logos/`))
+      - traefik.http.routers.dispatcharr-tv.tls=true
+      - traefik.http.routers.dispatcharr-tv.tls.certresolver=dns-cloudflare
+      - traefik.http.routers.dispatcharr-tv.priority=100
+      - traefik.http.routers.dispatcharr-tv.middlewares=dispatcharr-tv-ratelimit
+      - traefik.http.routers.dispatcharr-tv.service=dispatcharr-svc
+      # Streaming is one long-lived request, so a low average is fine; the burst covers
+      # a client fetching categories + logos on startup.
+      - traefik.http.middlewares.dispatcharr-tv-ratelimit.ratelimit.average=30
+      - traefik.http.middlewares.dispatcharr-tv-ratelimit.ratelimit.burst=60
+      - traefik.http.middlewares.dispatcharr-tv-ratelimit.ratelimit.period=1m
+
 
 


### PR DESCRIPTION
## What

Adds `tv.deercrest.info` — a second Traefik router on dispatcharr with **no authelia** — so IPTV players at Fosse Road can reach the Xtream Codes API. An IPTV player has no browser to complete an auth flow, so it cannot use `dispatcharr.deercrest.info`.

Auth is the XC credential: a `STREAMER`-level dispatcharr user (`fosse-tv`) with `custom_properties.xc_password`, capped at `stream_limit=1`.

## Why it's safe to run without authelia

**Default-deny by path.** The rule allow-lists only the XC endpoints plus `/api/channels/logos/`. Anything else on that host matches no router and Traefik returns 404. Verified:

| Path | Result |
|---|---|
| `/player_api.php` (valid creds) | 200 |
| `/output/m3u`, `/output/epg`, `/hdhr/lineup.json` | 404 |
| `/`, `/admin/`, `/api/channels/channels/` | 404 |
| `dispatcharr.deercrest.info` | 302 → authelia (unchanged) |

`/output/*` is deliberately excluded — it carries **no authentication of its own**. It's additionally pinned to private ranges (plus Tailscale's `100.64.0.0/10`) by dispatcharr's `network_access.M3U_EPG` ACL. Those ACLs are effective for internet clients because `get_client_ip` trusts `X-Forwarded-For` from private-range proxies, so it evaluates the real client IP rather than Traefik's.

`/api/channels/logos/` is unauthenticated PNGs, which the TV needs; the rest of `/api/` 401s regardless and isn't exposed here.

**Rate limited** at 30/min: XC credentials ride in the query string and URL path, and there is no lockout on failed XC auth.

## Trade-off to be aware of

This record **must be grey-cloud**, making it the one exception in the estate — Cloudflare's proxy breaks long-lived MPEG-TS (100s timeout) and free-tier video is against their ToS. The cost is that it **publishes the origin IP**.

It is therefore a **fallback only**. The TV normally reaches dispatcharr over Tailscale, and this route can be retired — at which point the DNS record should be deleted and `XC_API`/`STREAMS` returned to private ranges.

## NETWORK.md

Documents the tuner chain now having two independent consumers — Jellyfin (HDHR + XMLTV) and TiviMate (XC over Tailscale) — and records that **TiviMate is the live-TV client**: Jellyfin's Live TV path adds ~7.7s to every channel change (3s ffprobe + 3s HLS segment build + ~1s tuner connect), which is inherent to how it does Live TV and not tunable. Also adds the reasoning behind each `network_access` ACL value, including why `UI` must *not* be restricted to LAN.

## Verified

Streamed end-to-end over the public endpoint: 6.6 MB pulled, MPEG-TS sync `0x47` at every 188-byte boundary, valid cert.