### PR TITLE
fix(buzz): document TUNNEL_TOKEN in .env.sample

### DIFF
--- a/stacks/selfhosted/buzz/.env.sample
+++ b/stacks/selfhosted/buzz/.env.sample
@@ -53,3 +53,22 @@ BUZZ_S3_ADDRESSING_STYLE=path
 # Public ingress is cloudflared over buzz-net. 3000/3001/3002 are taken on this
 # host, hence 3080. Never bind this to 0.0.0.0.
 BUZZ_DEBUG_PORT=3080
+
+# ── Cloudflare Tunnel ────────────────────────────────────────────────────────
+# REQUIRED. compose.yaml has `TUNNEL_TOKEN: ${TUNNEL_TOKEN:?set TUNNEL_TOKEN}`,
+# so the stack hard-fails to start without this. It is the *connector*
+# credential that `cloudflared tunnel run` authenticates with — copy it from the
+# tunnel's page in the Cloudflare Zero Trust dashboard.
+#
+# Do NOT confuse this with a Cloudflare **API token**. They are different things:
+#   TUNNEL_TOKEN  — long-lived connector credential. Required at runtime, forever.
+#   CF_API_TOKEN  — provisioning only. Used ONCE to create the tunnel and its DNS
+#                   records. Nothing needs it afterwards; delete it in Cloudflare
+#                   and remove it from .env once the tunnel exists.
+#
+# Deleting TUNNEL_TOKEN takes the relay offline. Deleting CF_API_TOKEN does not.
+#
+# The live .env may also still carry CF_ACCOUNT_ID / CF_ZONE_ID / CF_TUNNEL_ID.
+# Those are identifiers rather than secrets, are not read by compose, and are
+# provisioning leftovers — safe to strip alongside CF_API_TOKEN.
+TUNNEL_TOKEN=CHANGE_ME_CLOUDFLARE_TUNNEL_CONNECTOR_TOKEN


### PR DESCRIPTION
## The gap

`compose.yaml` has:

```yaml
TUNNEL_TOKEN: ${TUNNEL_TOKEN:?set TUNNEL_TOKEN}
```

so the stack **hard-fails to start** without it — but `.env.sample` never mentioned it. Anyone rebuilding buzz from the sample hits an immediate error with no clue what is missing. The live `.env` carries five Cloudflare keys (`CF_API_TOKEN`, `CF_ACCOUNT_ID`, `CF_ZONE_ID`, `CF_TUNNEL_ID`, `TUNNEL_TOKEN`), none of them documented. This shipped in #287.

## Why it matters now

The provisioning token is pending deletion (it was exposed in plaintext and expires 2026-08-22). The sample needs to make unambiguous **which** Cloudflare credential is being retired, because the two are easy to confuse and the failure mode is asymmetric:

| Key | Role | If deleted |
|---|---|---|
| `TUNNEL_TOKEN` | Connector credential `cloudflared tunnel run` authenticates with | **Relay goes offline** |
| `CF_API_TOKEN` | Provisioning only — used once to create the tunnel and DNS records | No effect |

`CF_ACCOUNT_ID` / `CF_ZONE_ID` / `CF_TUNNEL_ID` are identifiers rather than secrets, are not read by compose, and are provisioning leftovers — safe to strip alongside `CF_API_TOKEN`.

Docs only. No behaviour change.